### PR TITLE
feat: add lottery simulator playground

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { ConnectFourPreview } from "./playgrounds/connect-four/Preview";
 import { TetrisAIPreview } from "./playgrounds/tetris-ai/Preview";
 import { BoidsPreview } from "./playgrounds/boids/Preview";
 import { ThreeBodyPreview } from "./playgrounds/three-body/Preview";
+import { LotteryPreview } from "./playgrounds/lottery/Preview";
 
 const playgrounds = [
   {
@@ -149,6 +150,14 @@ const playgrounds = [
     description: "Three gravitating stars. Stable dances or chaos, depending where you start.",
     href: "/playgrounds/three-body",
     preview: ThreeBodyPreview,
+  },
+  {
+    id: "lottery",
+    title: "Lottery Simulator",
+    description:
+      "Play the UK Lotto at £2 a ticket. Run a million draws and watch the house always win.",
+    href: "/playgrounds/lottery",
+    preview: LotteryPreview,
   },
 ];
 

--- a/src/app/playgrounds/lottery/Preview.tsx
+++ b/src/app/playgrounds/lottery/Preview.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+const BALLS = [7, 14, 23, 31, 42, 58];
+
+export function LotteryPreview() {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-[#fffef5] p-3">
+      <div className="flex items-center gap-1.5">
+        {BALLS.map((n) => (
+          <span
+            key={n}
+            className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black bg-white font-mono text-[11px] font-bold tabular-nums shadow-[1px_1px_0px_0px_rgba(0,0,0,1)]"
+          >
+            {n}
+          </span>
+        ))}
+        <span className="px-0.5 font-mono text-[10px] text-black/40">+</span>
+        <span className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black bg-amber-300 font-mono text-[11px] font-bold tabular-nums shadow-[1px_1px_0px_0px_rgba(0,0,0,1)]">
+          3
+        </span>
+      </div>
+      <div className="text-center">
+        <div className="font-roboto-slab text-3xl font-black leading-none text-black">
+          £6.7M
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-widest text-black/50">
+          jackpot · 1 in 45,057,474
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/Preview.tsx
+++ b/src/app/playgrounds/lottery/Preview.tsx
@@ -1,30 +1,51 @@
 "use client";
 
-const BALLS = [7, 14, 23, 31, 42, 58];
+import { display } from "./_lib/fonts";
+import { ballColor, INK } from "./_lib/ballColors";
+
+const BALLS = [7, 14, 23, 38, 49, 58];
 
 export function LotteryPreview() {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-[#fffef5] p-3">
-      <div className="flex items-center gap-1.5">
-        {BALLS.map((n) => (
-          <span
-            key={n}
-            className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black bg-white font-mono text-[11px] font-bold tabular-nums shadow-[1px_1px_0px_0px_rgba(0,0,0,1)]"
-          >
-            {n}
-          </span>
-        ))}
-        <span className="px-0.5 font-mono text-[10px] text-black/40">+</span>
-        <span className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-black bg-amber-300 font-mono text-[11px] font-bold tabular-nums shadow-[1px_1px_0px_0px_rgba(0,0,0,1)]">
-          3
-        </span>
+    <div
+      className="flex h-full w-full flex-col items-center justify-center gap-3 p-3"
+      style={{
+        backgroundColor: "#08060d",
+        backgroundImage:
+          "radial-gradient(110% 80% at 50% -10%, rgba(150,110,55,0.4), rgba(8,6,12,0) 65%)",
+      }}
+    >
+      <div className="flex items-center gap-1">
+        {BALLS.map((n) => {
+          const c = ballColor(n);
+          return (
+            <span
+              key={n}
+              className="relative grid h-6 w-6 place-items-center rounded-full text-[9px] font-bold tabular-nums"
+              style={{
+                backgroundImage: `radial-gradient(circle at 34% 28%, ${c.from} 0%, ${c.to} 70%)`,
+                color: INK,
+                boxShadow: "0 2px 5px rgba(0,0,0,0.5)",
+                fontFamily: "var(--font-mono), monospace",
+              }}
+            >
+              <span className="absolute left-[20%] top-[16%] h-[26%] w-[30%] rounded-full bg-white/70 blur-[1px]" />
+              <span className="relative">{n}</span>
+            </span>
+          );
+        })}
       </div>
       <div className="text-center">
-        <div className="font-roboto-slab text-3xl font-black leading-none text-black">
+        <div
+          className={`${display.className} gold-foil text-[28px] font-black italic leading-none`}
+        >
           £6.7M
         </div>
-        <div className="font-mono text-[9px] uppercase tracking-widest text-black/50">
-          jackpot · 1 in 45,057,474
+        <div
+          className="mt-0.5 text-[7px] uppercase tracking-[0.3em] text-[#f3e9d2]/45"
+          style={{ fontFamily: "var(--font-mono), monospace" }}
+        >
+          one in 45,057,474
         </div>
       </div>
     </div>

--- a/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
@@ -1,36 +1,75 @@
 import { twMerge } from "tailwind-merge";
+import { ballColor, INK } from "../../_lib/ballColors";
 
-type BallVariant = "default" | "matched" | "bonus" | "bonusMatched" | "ticket";
+type BallSize = "sm" | "md" | "lg";
 
 interface BallProps {
   value: number;
-  variant?: BallVariant;
-  size?: "sm" | "md";
-  /** Stagger index used to delay the pop-in animation. */
-  popIndex?: number;
+  size?: BallSize;
+  /** Pulses a coloured halo — used for matched draw balls. */
+  matched?: boolean;
+  /** Drops saturation/opacity for non-winning draw balls. */
+  faded?: boolean;
+  /** Wraps the sphere in a gold collar for the bonus ball. */
+  bonus?: boolean;
+  /** Stagger index; when set the ball tumbles in on mount. */
+  dropIndex?: number;
 }
 
-const variantClasses: Record<BallVariant, string> = {
-  default: "bg-white text-black",
-  ticket: "bg-black text-[#fffef5]",
-  matched: "bg-lime-300 text-black",
-  bonus: "bg-amber-200 text-black",
-  bonusMatched: "bg-amber-400 text-black",
+const sizeMap: Record<BallSize, { box: string; text: string }> = {
+  sm: { box: "w-8 h-8", text: "text-[11px]" },
+  md: { box: "w-12 h-12", text: "text-base" },
+  lg: { box: "w-16 h-16", text: "text-2xl" },
 };
 
-export function Ball({ value, variant = "default", size = "md", popIndex }: BallProps) {
-  const animate = popIndex !== undefined;
+export function Ball({
+  value,
+  size = "md",
+  matched = false,
+  faded = false,
+  bonus = false,
+  dropIndex,
+}: BallProps) {
+  const c = ballColor(value);
+  const s = sizeMap[size];
+  const dropping = dropIndex !== undefined;
+
   return (
     <span
       className={twMerge(
-        "inline-flex items-center justify-center rounded-full border-2 border-black font-mono font-bold tabular-nums shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]",
-        size === "md" ? "w-11 h-11 text-base" : "w-8 h-8 text-xs",
-        variantClasses[variant],
-        animate && "animate-[ball-pop_0.35s_ease-out_both]"
+        "relative inline-grid place-items-center rounded-full select-none",
+        s.box,
+        bonus && "ring-2 ring-[#e9c66a] ring-offset-2 ring-offset-transparent",
+        faded && "opacity-45 saturate-50",
+        dropping && "animate-[ball-drop_0.6s_cubic-bezier(0.2,0.7,0.3,1.4)_both]",
+        matched && "animate-[ball-glow_1.9s_ease-in-out_infinite]"
       )}
-      style={animate ? { animationDelay: `${popIndex * 90}ms` } : undefined}
+      style={{
+        backgroundImage: `radial-gradient(circle at 33% 27%, ${c.from} 0%, ${c.to} 68%, ${c.to} 100%)`,
+        boxShadow: matched
+          ? `0 6px 16px rgba(0,0,0,0.55), 0 0 22px 3px ${c.glow}`
+          : "0 6px 16px rgba(0,0,0,0.55), inset 0 -4px 8px rgba(0,0,0,0.35), inset 0 3px 6px rgba(255,255,255,0.35)",
+        ["--ball-glow" as string]: c.glow,
+        animationDelay: dropping ? `${dropIndex * 110}ms` : undefined,
+        color: INK,
+      }}
     >
-      {value}
+      {/* specular highlight */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute left-[18%] top-[14%] h-[28%] w-[34%] rounded-full bg-white/75 blur-[2px]"
+      />
+      {bonus && (
+        <span
+          aria-hidden
+          className="font-ticker absolute -bottom-4 left-1/2 -translate-x-1/2 whitespace-nowrap text-[7px] uppercase tracking-[0.25em] text-[#e9c66a]"
+        >
+          bonus
+        </span>
+      )}
+      <span className={twMerge("font-ticker relative font-bold tabular-nums", s.text)}>
+        {value}
+      </span>
     </span>
   );
 }

--- a/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
@@ -1,0 +1,36 @@
+import { twMerge } from "tailwind-merge";
+
+type BallVariant = "default" | "matched" | "bonus" | "bonusMatched" | "ticket";
+
+interface BallProps {
+  value: number;
+  variant?: BallVariant;
+  size?: "sm" | "md";
+  /** Stagger index used to delay the pop-in animation. */
+  popIndex?: number;
+}
+
+const variantClasses: Record<BallVariant, string> = {
+  default: "bg-white text-black",
+  ticket: "bg-black text-[#fffef5]",
+  matched: "bg-lime-300 text-black",
+  bonus: "bg-amber-200 text-black",
+  bonusMatched: "bg-amber-400 text-black",
+};
+
+export function Ball({ value, variant = "default", size = "md", popIndex }: BallProps) {
+  const animate = popIndex !== undefined;
+  return (
+    <span
+      className={twMerge(
+        "inline-flex items-center justify-center rounded-full border-2 border-black font-mono font-bold tabular-nums shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]",
+        size === "md" ? "w-11 h-11 text-base" : "w-8 h-8 text-xs",
+        variantClasses[variant],
+        animate && "animate-[ball-pop_0.35s_ease-out_both]"
+      )}
+      style={animate ? { animationDelay: `${popIndex * 90}ms` } : undefined}
+    >
+      {value}
+    </span>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Ball.tsx
@@ -18,7 +18,7 @@ interface BallProps {
 
 const sizeMap: Record<BallSize, { box: string; text: string }> = {
   sm: { box: "w-8 h-8", text: "text-[11px]" },
-  md: { box: "w-12 h-12", text: "text-base" },
+  md: { box: "w-10 h-10 sm:w-12 sm:h-12", text: "text-sm sm:text-base" },
   lg: { box: "w-16 h-16", text: "text-2xl" },
 };
 

--- a/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
@@ -35,7 +35,7 @@ export function DrawDisplay({ draw, ticket, drawKey }: DrawDisplayProps) {
 
   return (
     <div className="flex flex-col items-center gap-5" key={drawKey}>
-      <div className="flex flex-wrap items-center justify-center gap-2.5">
+      <div className="flex flex-wrap items-center justify-center gap-1.5 sm:gap-2.5">
         {draw.main.map((n, i) => {
           const hit = ticketSet.has(n);
           return (

--- a/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
@@ -6,15 +6,25 @@ import { TIER_BY_ID, type DrawResult } from "../../_lib/lottery";
 interface DrawDisplayProps {
   draw: DrawResult | null;
   ticket: number[];
-  /** Bumped on every new single draw to retrigger the pop-in animation. */
+  /** Bumped on every new single draw to retrigger the drop animation. */
   drawKey: number;
 }
 
 export function DrawDisplay({ draw, ticket, drawKey }: DrawDisplayProps) {
   if (!draw) {
     return (
-      <div className="flex h-28 items-center justify-center border-2 border-dashed border-black/30">
-        <p className="font-mono text-sm text-black/40">No draw yet — press Play.</p>
+      <div className="flex h-[120px] flex-col items-center justify-center gap-2">
+        <div className="flex gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <span
+              key={i}
+              className="h-12 w-12 rounded-full border border-dashed border-[#f3e9d2]/20"
+            />
+          ))}
+        </div>
+        <p className="font-ticker text-xs uppercase tracking-[0.3em] text-[#f3e9d2]/35">
+          awaiting the draw
+        </p>
       </div>
     );
   }
@@ -24,39 +34,46 @@ export function DrawDisplay({ draw, ticket, drawKey }: DrawDisplayProps) {
   const tierLabel = draw.tier ? TIER_BY_ID[draw.tier].label : null;
 
   return (
-    <div className="space-y-3" key={drawKey}>
-      <div className="flex flex-wrap items-center gap-2">
-        {draw.main.map((n, i) => (
-          <Ball
-            key={n}
-            value={n}
-            variant={ticketSet.has(n) ? "matched" : "default"}
-            popIndex={i}
-          />
-        ))}
-        <span className="px-1 font-mono text-xs text-black/40">+</span>
+    <div className="flex flex-col items-center gap-5" key={drawKey}>
+      <div className="flex flex-wrap items-center justify-center gap-2.5">
+        {draw.main.map((n, i) => {
+          const hit = ticketSet.has(n);
+          return (
+            <Ball
+              key={n}
+              value={n}
+              matched={hit}
+              faded={!hit}
+              dropIndex={i}
+            />
+          );
+        })}
+        <span
+          aria-hidden
+          className="mx-1 h-12 w-px bg-gradient-to-b from-transparent via-[#e9c66a]/60 to-transparent"
+        />
         <Ball
           value={draw.bonus}
-          variant={ticketSet.has(draw.bonus) ? "bonusMatched" : "bonus"}
-          popIndex={draw.main.length}
+          bonus
+          matched={ticketSet.has(draw.bonus)}
+          faded={!ticketSet.has(draw.bonus)}
+          dropIndex={draw.main.length}
         />
       </div>
 
       <div
         className={twMerge(
-          "border-2 border-black px-3 py-2 font-mono text-sm font-bold",
-          won ? "bg-lime-300" : "bg-white"
+          "font-ticker text-center text-sm uppercase tracking-[0.18em]",
+          won ? "text-[#f6e3a1]" : "text-[#f3e9d2]/45"
         )}
       >
         {won ? (
           <span>
-            {tierLabel} matched — won {money(draw.payout)}!
+            {tierLabel} — <span className="gold-foil font-bold">{money(draw.payout)}</span>
           </span>
         ) : (
-          <span className="text-black/60">
-            {draw.matchCount === 1
-              ? "1 ball matched. No prize."
-              : `${draw.matchCount} balls matched. No prize.`}
+          <span>
+            {draw.matchCount === 1 ? "one ball" : `${draw.matchCount} balls`} · no prize
           </span>
         )}
       </div>

--- a/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/DrawDisplay.tsx
@@ -1,0 +1,65 @@
+import { twMerge } from "tailwind-merge";
+import { Ball } from "./Ball";
+import { money } from "../../_lib/format";
+import { TIER_BY_ID, type DrawResult } from "../../_lib/lottery";
+
+interface DrawDisplayProps {
+  draw: DrawResult | null;
+  ticket: number[];
+  /** Bumped on every new single draw to retrigger the pop-in animation. */
+  drawKey: number;
+}
+
+export function DrawDisplay({ draw, ticket, drawKey }: DrawDisplayProps) {
+  if (!draw) {
+    return (
+      <div className="flex h-28 items-center justify-center border-2 border-dashed border-black/30">
+        <p className="font-mono text-sm text-black/40">No draw yet — press Play.</p>
+      </div>
+    );
+  }
+
+  const ticketSet = new Set(ticket);
+  const won = draw.tier !== null;
+  const tierLabel = draw.tier ? TIER_BY_ID[draw.tier].label : null;
+
+  return (
+    <div className="space-y-3" key={drawKey}>
+      <div className="flex flex-wrap items-center gap-2">
+        {draw.main.map((n, i) => (
+          <Ball
+            key={n}
+            value={n}
+            variant={ticketSet.has(n) ? "matched" : "default"}
+            popIndex={i}
+          />
+        ))}
+        <span className="px-1 font-mono text-xs text-black/40">+</span>
+        <Ball
+          value={draw.bonus}
+          variant={ticketSet.has(draw.bonus) ? "bonusMatched" : "bonus"}
+          popIndex={draw.main.length}
+        />
+      </div>
+
+      <div
+        className={twMerge(
+          "border-2 border-black px-3 py-2 font-mono text-sm font-bold",
+          won ? "bg-lime-300" : "bg-white"
+        )}
+      >
+        {won ? (
+          <span>
+            {tierLabel} matched — won {money(draw.payout)}!
+          </span>
+        ) : (
+          <span className="text-black/60">
+            {draw.matchCount === 1
+              ? "1 ball matched. No prize."
+              : `${draw.matchCount} balls matched. No prize.`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { twMerge } from "tailwind-merge";
 import {
   singleDraw,
   runBatch,
@@ -13,11 +12,21 @@ import {
   type TierCounts,
 } from "../../_lib/lottery";
 import { money, count } from "../../_lib/format";
+import { display, mono } from "../../_lib/fonts";
 import { Ball } from "./Ball";
 import { NumberPicker } from "./NumberPicker";
 import { DrawDisplay } from "./DrawDisplay";
 import { OddsTable } from "./OddsTable";
 import { Stats, type StatsData } from "./Stats";
+
+const GRAIN =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E\")";
+
+const STAGE_BG = [
+  GRAIN,
+  "radial-gradient(115% 75% at 50% -8%, rgba(150,110,55,0.38), rgba(60,30,45,0.14) 38%, rgba(8,6,12,0) 68%)",
+  "radial-gradient(80% 50% at 50% 115%, rgba(120,40,55,0.16), rgba(8,6,12,0) 70%)",
+].join(", ");
 
 const ZERO_STATS: StatsData = { draws: 0, spent: 0, won: 0, biggestWin: 0 };
 const CHUNK_SIZE = 50_000;
@@ -132,172 +141,197 @@ export function Lottery() {
 
   const batchPct = batch ? Math.round((batch.done / batch.total) * 100) : 0;
 
+  const remaining = PICK - ticket.length;
+
   return (
     <div
-      className="h-full overflow-y-auto"
-      style={{
-        backgroundColor: "#fffef5",
-        backgroundImage: `
-          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
-        `,
-        backgroundSize: "32px 32px",
-      }}
+      className={`${display.variable} ${mono.variable} h-full overflow-y-auto text-[#f3e9d2]`}
+      style={{ backgroundColor: "#08060d", backgroundImage: STAGE_BG }}
     >
-      <div className="mx-auto max-w-5xl px-4 py-8">
-        <header className="mb-8">
-          <div className="mb-4 h-1 bg-black" />
-          <p className="mb-1 font-mono text-xs uppercase tracking-widest text-black/50">
-            UK Lotto · {money(TICKET_PRICE)} a ticket
-          </p>
-          <h1 className="font-roboto-slab text-[clamp(2.5rem,8vw,4.5rem)] font-black leading-none tracking-tight text-black">
-            Lottery Simulator
+      <div className="mx-auto max-w-4xl px-4 py-10 sm:py-14">
+        {/* Masthead */}
+        <header className="text-center">
+          <div className="mb-5 flex items-center justify-center gap-3">
+            <span className="h-px w-12 bg-gradient-to-r from-transparent to-[#e9c66a]/50" />
+            <span className="font-ticker text-[10px] uppercase tracking-[0.42em] text-[#e9c66a]/65">
+              the national draw
+            </span>
+            <span className="h-px w-12 bg-gradient-to-l from-transparent to-[#e9c66a]/50" />
+          </div>
+          <h1 className="font-marquee text-[clamp(2.8rem,9vw,6rem)] font-black italic leading-[0.88]">
+            The{" "}
+            <span className="gold-foil animate-[foil-shimmer_7s_linear_infinite]">
+              Midnight
+            </span>{" "}
+            Draw
           </h1>
-          <p className="mt-3 max-w-lg font-mono text-sm text-black/50">
-            Pick 6 from 59. Match the 6 drawn balls to win. Play one ticket or
-            burn through a million — and watch the house take its cut.
+          <p className="mx-auto mt-4 max-w-md font-ticker text-[11px] uppercase tracking-[0.2em] text-[#f3e9d2]/45">
+            six numbers · one in 45,057,474 · {money(TICKET_PRICE)} a line
           </p>
+
+          <div className="mt-9">
+            <div className="font-ticker text-[10px] uppercase tracking-[0.42em] text-[#f3e9d2]/40">
+              tonight&rsquo;s top prize
+            </div>
+            <div className="gold-foil animate-[foil-shimmer_6s_linear_infinite] font-marquee mt-1 text-[clamp(3rem,11vw,7rem)] font-black leading-none">
+              {money(6_700_000)}
+            </div>
+          </div>
         </header>
 
-        <div className="grid gap-6 lg:grid-cols-2">
-          {/* Ticket picker */}
-          <section className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="font-roboto-slab text-lg font-black">Your ticket</h2>
-              <span className="font-mono text-xs text-black/50">
-                {ticket.length}/{PICK} picked
+        {/* Draw chamber */}
+        <section
+          className="relative mt-12 overflow-hidden rounded-2xl border border-[#e9c66a]/25 px-6 py-9"
+          style={{
+            backgroundImage:
+              "radial-gradient(120% 120% at 50% 0%, rgba(44,30,54,0.6), rgba(10,8,16,0.82))",
+            boxShadow:
+              "inset 0 1px 0 rgba(255,255,255,0.06), inset 0 28px 56px rgba(0,0,0,0.5), 0 30px 60px rgba(0,0,0,0.45)",
+          }}
+        >
+          <div className="mb-6 flex items-center justify-center gap-2">
+            <span className="h-1.5 w-1.5 animate-[blink_1.5s_ease-in-out_infinite] rounded-full bg-[#e0556a]" />
+            <span className="font-ticker text-[10px] uppercase tracking-[0.38em] text-[#f3e9d2]/45">
+              latest draw
+            </span>
+          </div>
+          <DrawDisplay draw={lastDraw} ticket={ticket} drawKey={drawKey} />
+        </section>
+
+        {/* Betting floor */}
+        <div className="mt-6 grid gap-5 lg:grid-cols-2">
+          {/* Your line */}
+          <section className="rounded-xl border border-[#f3e9d2]/12 bg-[#0f0b14]/60 p-5 backdrop-blur-sm">
+            <div className="mb-4 flex items-baseline justify-between">
+              <h2 className="font-marquee text-xl italic">Your line</h2>
+              <span className="font-ticker text-[11px] uppercase tracking-[0.2em] text-[#f3e9d2]/40">
+                {ticket.length}/{PICK} marked
               </span>
             </div>
 
-            <div className="mb-4 flex min-h-[44px] flex-wrap items-center gap-2">
+            <div className="mb-5 flex min-h-[48px] flex-wrap items-center gap-2.5">
               {ticket.length > 0 ? (
-                ticket.map((n) => <Ball key={n} value={n} variant="ticket" />)
+                ticket.map((n) => <Ball key={n} value={n} />)
               ) : (
-                <span className="font-mono text-sm text-black/40">
-                  Pick 6 numbers, or hit Lucky Dip.
+                <span className="font-ticker text-[11px] uppercase tracking-[0.2em] text-[#f3e9d2]/35">
+                  mark six numbers below
                 </span>
               )}
             </div>
 
-            <NumberPicker
-              ticket={ticket}
-              onToggle={toggleNumber}
-              disabled={running}
-            />
+            <NumberPicker ticket={ticket} onToggle={toggleNumber} disabled={running} />
 
-            <div className="mt-4 flex gap-2">
+            <div className="mt-5 flex gap-2.5">
               <button
                 type="button"
                 onClick={handleLuckyDip}
                 disabled={running}
-                className="flex-1 border-2 border-black bg-amber-300 px-3 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+                className="font-ticker flex-1 rounded-md border border-[#e9c66a]/50 bg-[#e9c66a]/10 px-4 py-2.5 text-[11px] font-bold uppercase tracking-[0.18em] text-[#f6e3a1] transition-colors hover:bg-[#e9c66a]/20 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-[#e9c66a]/10"
               >
-                🎲 Lucky Dip
+                Quick pick
               </button>
               <button
                 type="button"
                 onClick={handleClearTicket}
                 disabled={running || ticket.length === 0}
-                className="border-2 border-black bg-white px-3 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+                className="font-ticker rounded-md border border-[#f3e9d2]/15 px-4 py-2.5 text-[11px] font-bold uppercase tracking-[0.18em] text-[#f3e9d2]/60 transition-colors hover:border-[#f3e9d2]/40 hover:text-[#f3e9d2] disabled:cursor-not-allowed disabled:opacity-30"
               >
                 Clear
               </button>
             </div>
           </section>
 
-          {/* Draw + controls */}
-          <section className="flex flex-col gap-4">
-            <div className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-              <h2 className="mb-3 font-roboto-slab text-lg font-black">
-                Latest draw
-              </h2>
-              <DrawDisplay draw={lastDraw} ticket={ticket} drawKey={drawKey} />
-            </div>
+          {/* Place your bet */}
+          <section className="flex flex-col rounded-xl border border-[#f3e9d2]/12 bg-[#0f0b14]/60 p-5 backdrop-blur-sm">
+            <h2 className="font-marquee mb-4 text-xl italic">Place your bet</h2>
 
-            <div className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
-              <button
-                type="button"
-                onClick={play}
-                disabled={!ready || running}
-                className="mb-3 w-full border-2 border-black bg-lime-400 px-4 py-3 font-roboto-slab text-lg font-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
-              >
-                Play ({money(TICKET_PRICE)})
-              </button>
+            <button
+              type="button"
+              onClick={play}
+              disabled={!ready || running}
+              className="font-marquee rounded-lg px-6 py-4 text-lg font-black italic text-[#1b1208] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:translate-y-0"
+              style={{
+                backgroundImage:
+                  "linear-gradient(100deg,#f7e7ad,#d8b24a 45%,#c69a2f)",
+                boxShadow:
+                  "0 10px 24px rgba(216,178,74,0.25), inset 0 1px 0 rgba(255,255,255,0.5)",
+              }}
+            >
+              Play this line — {money(TICKET_PRICE)}
+            </button>
 
-              <div className="flex gap-2">
+            <div className="mt-5">
+              <div className="mb-2 font-ticker text-[10px] uppercase tracking-[0.3em] text-[#f3e9d2]/40">
+                or auto-play
+              </div>
+              <div className="grid grid-cols-3 gap-2">
                 {BATCHES.map((b) => (
                   <button
                     key={b.n}
                     type="button"
                     onClick={() => runMany(b.n)}
                     disabled={!ready || running}
-                    className="flex-1 border-2 border-black bg-white px-2 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+                    className="font-ticker rounded-md border border-[#f3e9d2]/15 px-2 py-2.5 text-sm font-bold tabular-nums text-[#f3e9d2]/70 transition-colors hover:border-[#e9c66a]/50 hover:text-[#f6e3a1] disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:border-[#f3e9d2]/15 disabled:hover:text-[#f3e9d2]/70"
                   >
                     {b.label}
                   </button>
                 ))}
               </div>
-
-              {batch && (
-                <div className="mt-3">
-                  <div className="mb-1 flex justify-between font-mono text-xs text-black/50">
-                    <span>Drawing…</span>
-                    <span>
-                      {count(batch.done)} / {count(batch.total)}
-                    </span>
-                  </div>
-                  <div className="h-3 border-2 border-black bg-white">
-                    <div
-                      className="h-full bg-lime-400 transition-all"
-                      style={{ width: `${batchPct}%` }}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {!ready && !running && (
-                <p className="mt-3 font-mono text-xs text-red-600">
-                  Pick {PICK - ticket.length} more number
-                  {PICK - ticket.length === 1 ? "" : "s"} to play.
-                </p>
-              )}
             </div>
+
+            {batch && (
+              <div className="mt-5">
+                <div className="mb-1.5 flex justify-between font-ticker text-[10px] uppercase tracking-[0.2em] text-[#f3e9d2]/45">
+                  <span>drawing…</span>
+                  <span className="tabular-nums">
+                    {count(batch.done)} / {count(batch.total)}
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-[#f3e9d2]/10">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-[#d8b24a] to-[#f7e7ad] transition-[width] duration-150"
+                    style={{ width: `${batchPct}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {!ready && !running && (
+              <p className="mt-4 font-ticker text-[11px] uppercase tracking-[0.15em] text-[#e0556a]/80">
+                mark {remaining} more number{remaining === 1 ? "" : "s"} to play
+              </p>
+            )}
+
+            <p className="mt-auto pt-5 font-ticker text-[10px] leading-relaxed text-[#f3e9d2]/30">
+              Every line costs {money(TICKET_PRICE)}, win or lose. Watch the
+              ledger.
+            </p>
           </section>
         </div>
 
-        {/* Stats */}
+        {/* The ledger */}
         <section className="mt-6">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="font-roboto-slab text-lg font-black">Your run</h2>
+          <div className="mb-3 flex items-center justify-end">
             <button
               type="button"
               onClick={reset}
               disabled={running || stats.draws === 0}
-              className="border-2 border-black bg-white px-3 py-1.5 font-mono text-xs font-bold shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+              className="font-ticker rounded-md border border-[#f3e9d2]/15 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.2em] text-[#f3e9d2]/55 transition-colors hover:border-[#f3e9d2]/40 hover:text-[#f3e9d2] disabled:cursor-not-allowed disabled:opacity-25"
             >
-              Reset
+              Reset run
             </button>
           </div>
           <Stats {...stats} />
         </section>
 
-        {/* Odds + breakdown */}
+        {/* Prize structure */}
         <section className="mt-6">
-          <h2 className="mb-3 font-roboto-slab text-lg font-black">
-            Odds &amp; prizes
-          </h2>
           <OddsTable tierCounts={tierCounts} />
-          <p
-            className={twMerge(
-              "mt-3 font-mono text-xs text-black/40",
-              stats.draws === 0 && "opacity-60"
-            )}
-          >
-            Odds shown as published &quot;x to 1&quot;. Your wins are the real
-            results of {count(stats.draws)} simulated draw
-            {stats.draws === 1 ? "" : "s"}.
-          </p>
         </section>
+
+        <p className="mt-10 text-center font-ticker text-[10px] uppercase tracking-[0.28em] text-[#f3e9d2]/25">
+          simulated · no money changes hands · the only winning move is not to play
+        </p>
       </div>
     </div>
   );

--- a/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
@@ -6,6 +6,7 @@ import {
   runBatch,
   luckyDip,
   emptyTierCounts,
+  payoutFor,
   PICK,
   TICKET_PRICE,
   type DrawResult,
@@ -30,6 +31,10 @@ const STAGE_BG = [
 
 const ZERO_STATS: StatsData = { draws: 0, spent: 0, won: 0, biggestWin: 0 };
 const CHUNK_SIZE = 50_000;
+// Bigger chunks for the open-ended jackpot chase — fewer rAF hops over the
+// ~45M draws it averages. Capped so a freak dry run can't loop forever.
+const JACKPOT_CHUNK = 200_000;
+const JACKPOT_MAX = 2_000_000_000;
 
 // A fixed starter ticket keeps SSR and client markup identical; Lucky Dip
 // randomises it after mount.
@@ -40,6 +45,11 @@ const BATCHES = [
   { label: "×10k", n: 10_000 },
   { label: "×1M", n: 1_000_000 },
 ];
+
+type RunState =
+  | { kind: "count"; done: number; total: number }
+  | { kind: "jackpot"; done: number }
+  | null;
 
 function mergeTierCounts(a: TierCounts, b: TierCounts): TierCounts {
   const out = { ...a };
@@ -55,14 +65,15 @@ export function Lottery() {
   const [drawKey, setDrawKey] = useState(0);
   const [stats, setStats] = useState<StatsData>(ZERO_STATS);
   const [tierCounts, setTierCounts] = useState<TierCounts>(emptyTierCounts);
-  const [batch, setBatch] = useState<{ done: number; total: number } | null>(null);
+  const [run, setRun] = useState<RunState>(null);
 
   const rafRef = useRef<number>(0);
+  const abortRef = useRef(false);
 
   useEffect(() => () => cancelAnimationFrame(rafRef.current), []);
 
   const ready = ticket.length === PICK;
-  const running = batch !== null;
+  const running = run !== null;
 
   const toggleNumber = useCallback(
     (n: number) => {
@@ -103,34 +114,83 @@ export function Lottery() {
     }
   }, [ready, running, ticket]);
 
+  const applyBatch = useCallback((res: ReturnType<typeof runBatch>) => {
+    setStats((s) => ({
+      draws: s.draws + res.draws,
+      spent: s.spent + res.spent,
+      won: s.won + res.won,
+      biggestWin: Math.max(s.biggestWin, res.biggestWin),
+    }));
+    setTierCounts((tc) => mergeTierCounts(tc, res.tierCounts));
+  }, []);
+
   const runMany = useCallback(
     (total: number) => {
       if (!ready || running) return;
-      setBatch({ done: 0, total });
+      abortRef.current = false;
+      setRun({ kind: "count", done: 0, total });
       let remaining = total;
 
       const tick = () => {
+        if (abortRef.current) return;
         const n = Math.min(CHUNK_SIZE, remaining);
-        const res = runBatch(ticket, n);
-        setStats((s) => ({
-          draws: s.draws + res.draws,
-          spent: s.spent + res.spent,
-          won: s.won + res.won,
-          biggestWin: Math.max(s.biggestWin, res.biggestWin),
-        }));
-        setTierCounts((tc) => mergeTierCounts(tc, res.tierCounts));
+        applyBatch(runBatch(ticket, n));
         remaining -= n;
-        setBatch({ done: total - remaining, total });
+        setRun({ kind: "count", done: total - remaining, total });
         if (remaining > 0) {
           rafRef.current = requestAnimationFrame(tick);
         } else {
-          setBatch(null);
+          setRun(null);
         }
       };
       rafRef.current = requestAnimationFrame(tick);
     },
-    [ready, running, ticket]
+    [ready, running, ticket, applyBatch]
   );
+
+  const chaseJackpot = useCallback(() => {
+    if (!ready || running) return;
+    abortRef.current = false;
+    setRun({ kind: "jackpot", done: 0 });
+    let total = 0;
+
+    const tick = () => {
+      if (abortRef.current) return;
+      const res = runBatch(ticket, JACKPOT_CHUNK, undefined, {
+        stopOnJackpot: true,
+      });
+      applyBatch(res);
+      total += res.draws;
+      setRun({ kind: "jackpot", done: total });
+
+      if (res.hitJackpot) {
+        // The winning line is, by definition, the ticket itself.
+        setLastDraw({
+          main: [...ticket].sort((a, b) => a - b),
+          bonus: res.jackpotBonus,
+          matchCount: PICK,
+          bonusMatched: false,
+          tier: "match6",
+          payout: payoutFor("match6"),
+        });
+        setDrawKey((k) => k + 1);
+        setRun(null);
+        return;
+      }
+      if (total >= JACKPOT_MAX) {
+        setRun(null);
+        return;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+  }, [ready, running, ticket, applyBatch]);
+
+  const stopRun = useCallback(() => {
+    abortRef.current = true;
+    cancelAnimationFrame(rafRef.current);
+    setRun(null);
+  }, []);
 
   const reset = useCallback(() => {
     if (running) return;
@@ -139,7 +199,11 @@ export function Lottery() {
     setLastDraw(null);
   }, [running]);
 
-  const batchPct = batch ? Math.round((batch.done / batch.total) * 100) : 0;
+  const countRun = run?.kind === "count" ? run : null;
+  const jackpotRun = run?.kind === "jackpot" ? run : null;
+  const batchPct = countRun
+    ? Math.round((countRun.done / countRun.total) * 100)
+    : 0;
 
   const remaining = PICK - ticket.length;
 
@@ -279,12 +343,26 @@ export function Lottery() {
               </div>
             </div>
 
-            {batch && (
+            <div className="mt-3 border-t border-[#f3e9d2]/10 pt-3">
+              <button
+                type="button"
+                onClick={chaseJackpot}
+                disabled={!ready || running}
+                className="font-ticker w-full rounded-md border border-[#e0556a]/45 bg-[#e0556a]/10 px-4 py-3 text-[11px] font-bold uppercase tracking-[0.18em] text-[#ff8a9c] transition-colors hover:border-[#e0556a]/70 hover:bg-[#e0556a]/20 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-[#e0556a]/10"
+              >
+                Chase the jackpot
+              </button>
+              <p className="mt-1.5 font-ticker text-[9px] uppercase tracking-[0.18em] text-[#f3e9d2]/30">
+                draws until 6 balls hit — could cost you millions
+              </p>
+            </div>
+
+            {countRun && (
               <div className="mt-5">
                 <div className="mb-1.5 flex justify-between font-ticker text-[10px] uppercase tracking-[0.2em] text-[#f3e9d2]/45">
                   <span>drawing…</span>
                   <span className="tabular-nums">
-                    {count(batch.done)} / {count(batch.total)}
+                    {count(countRun.done)} / {count(countRun.total)}
                   </span>
                 </div>
                 <div className="h-1.5 overflow-hidden rounded-full bg-[#f3e9d2]/10">
@@ -294,6 +372,32 @@ export function Lottery() {
                   />
                 </div>
               </div>
+            )}
+
+            {jackpotRun && (
+              <div className="mt-5">
+                <div className="mb-1.5 flex justify-between font-ticker text-[10px] uppercase tracking-[0.2em]">
+                  <span className="animate-pulse text-[#ff8a9c]">
+                    chasing the jackpot…
+                  </span>
+                  <span className="tabular-nums text-[#f3e9d2]/55">
+                    {count(jackpotRun.done)} draws
+                  </span>
+                </div>
+                <div className="relative h-1.5 overflow-hidden rounded-full bg-[#f3e9d2]/10">
+                  <div className="absolute inset-y-0 w-1/4 animate-[chase-bar_1.1s_ease-in-out_infinite] rounded-full bg-gradient-to-r from-transparent via-[#e0556a] to-transparent" />
+                </div>
+              </div>
+            )}
+
+            {running && (
+              <button
+                type="button"
+                onClick={stopRun}
+                className="font-ticker mt-3 self-start rounded-md border border-[#f3e9d2]/20 px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.2em] text-[#f3e9d2]/60 transition-colors hover:border-[#f3e9d2]/50 hover:text-[#f3e9d2]"
+              >
+                Stop
+              </button>
             )}
 
             {!ready && !running && (

--- a/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { twMerge } from "tailwind-merge";
+import {
+  singleDraw,
+  runBatch,
+  luckyDip,
+  emptyTierCounts,
+  PICK,
+  TICKET_PRICE,
+  type DrawResult,
+  type TierCounts,
+} from "../../_lib/lottery";
+import { money, count } from "../../_lib/format";
+import { Ball } from "./Ball";
+import { NumberPicker } from "./NumberPicker";
+import { DrawDisplay } from "./DrawDisplay";
+import { OddsTable } from "./OddsTable";
+import { Stats, type StatsData } from "./Stats";
+
+const ZERO_STATS: StatsData = { draws: 0, spent: 0, won: 0, biggestWin: 0 };
+const CHUNK_SIZE = 50_000;
+
+// A fixed starter ticket keeps SSR and client markup identical; Lucky Dip
+// randomises it after mount.
+const DEFAULT_TICKET = [3, 11, 19, 27, 38, 49];
+
+const BATCHES = [
+  { label: "×100", n: 100 },
+  { label: "×10k", n: 10_000 },
+  { label: "×1M", n: 1_000_000 },
+];
+
+function mergeTierCounts(a: TierCounts, b: TierCounts): TierCounts {
+  const out = { ...a };
+  for (const key of Object.keys(b) as (keyof TierCounts)[]) {
+    out[key] += b[key];
+  }
+  return out;
+}
+
+export function Lottery() {
+  const [ticket, setTicket] = useState<number[]>(DEFAULT_TICKET);
+  const [lastDraw, setLastDraw] = useState<DrawResult | null>(null);
+  const [drawKey, setDrawKey] = useState(0);
+  const [stats, setStats] = useState<StatsData>(ZERO_STATS);
+  const [tierCounts, setTierCounts] = useState<TierCounts>(emptyTierCounts);
+  const [batch, setBatch] = useState<{ done: number; total: number } | null>(null);
+
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => () => cancelAnimationFrame(rafRef.current), []);
+
+  const ready = ticket.length === PICK;
+  const running = batch !== null;
+
+  const toggleNumber = useCallback(
+    (n: number) => {
+      if (running) return;
+      setTicket((prev) => {
+        if (prev.includes(n)) return prev.filter((x) => x !== n);
+        if (prev.length >= PICK) return prev;
+        return [...prev, n].sort((a, b) => a - b);
+      });
+    },
+    [running]
+  );
+
+  const handleLuckyDip = useCallback(() => {
+    if (running) return;
+    setTicket(luckyDip());
+  }, [running]);
+
+  const handleClearTicket = useCallback(() => {
+    if (running) return;
+    setTicket([]);
+  }, [running]);
+
+  const play = useCallback(() => {
+    if (!ready || running) return;
+    const result = singleDraw(ticket);
+    setLastDraw(result);
+    setDrawKey((k) => k + 1);
+    setStats((s) => ({
+      draws: s.draws + 1,
+      spent: s.spent + TICKET_PRICE,
+      won: s.won + result.payout,
+      biggestWin: Math.max(s.biggestWin, result.payout),
+    }));
+    if (result.tier) {
+      const tier = result.tier;
+      setTierCounts((tc) => ({ ...tc, [tier]: tc[tier] + 1 }));
+    }
+  }, [ready, running, ticket]);
+
+  const runMany = useCallback(
+    (total: number) => {
+      if (!ready || running) return;
+      setBatch({ done: 0, total });
+      let remaining = total;
+
+      const tick = () => {
+        const n = Math.min(CHUNK_SIZE, remaining);
+        const res = runBatch(ticket, n);
+        setStats((s) => ({
+          draws: s.draws + res.draws,
+          spent: s.spent + res.spent,
+          won: s.won + res.won,
+          biggestWin: Math.max(s.biggestWin, res.biggestWin),
+        }));
+        setTierCounts((tc) => mergeTierCounts(tc, res.tierCounts));
+        remaining -= n;
+        setBatch({ done: total - remaining, total });
+        if (remaining > 0) {
+          rafRef.current = requestAnimationFrame(tick);
+        } else {
+          setBatch(null);
+        }
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [ready, running, ticket]
+  );
+
+  const reset = useCallback(() => {
+    if (running) return;
+    setStats(ZERO_STATS);
+    setTierCounts(emptyTierCounts());
+    setLastDraw(null);
+  }, [running]);
+
+  const batchPct = batch ? Math.round((batch.done / batch.total) * 100) : 0;
+
+  return (
+    <div
+      className="h-full overflow-y-auto"
+      style={{
+        backgroundColor: "#fffef5",
+        backgroundImage: `
+          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
+        `,
+        backgroundSize: "32px 32px",
+      }}
+    >
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        <header className="mb-8">
+          <div className="mb-4 h-1 bg-black" />
+          <p className="mb-1 font-mono text-xs uppercase tracking-widest text-black/50">
+            UK Lotto · {money(TICKET_PRICE)} a ticket
+          </p>
+          <h1 className="font-roboto-slab text-[clamp(2.5rem,8vw,4.5rem)] font-black leading-none tracking-tight text-black">
+            Lottery Simulator
+          </h1>
+          <p className="mt-3 max-w-lg font-mono text-sm text-black/50">
+            Pick 6 from 59. Match the 6 drawn balls to win. Play one ticket or
+            burn through a million — and watch the house take its cut.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Ticket picker */}
+          <section className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="font-roboto-slab text-lg font-black">Your ticket</h2>
+              <span className="font-mono text-xs text-black/50">
+                {ticket.length}/{PICK} picked
+              </span>
+            </div>
+
+            <div className="mb-4 flex min-h-[44px] flex-wrap items-center gap-2">
+              {ticket.length > 0 ? (
+                ticket.map((n) => <Ball key={n} value={n} variant="ticket" />)
+              ) : (
+                <span className="font-mono text-sm text-black/40">
+                  Pick 6 numbers, or hit Lucky Dip.
+                </span>
+              )}
+            </div>
+
+            <NumberPicker
+              ticket={ticket}
+              onToggle={toggleNumber}
+              disabled={running}
+            />
+
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={handleLuckyDip}
+                disabled={running}
+                className="flex-1 border-2 border-black bg-amber-300 px-3 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+              >
+                🎲 Lucky Dip
+              </button>
+              <button
+                type="button"
+                onClick={handleClearTicket}
+                disabled={running || ticket.length === 0}
+                className="border-2 border-black bg-white px-3 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+              >
+                Clear
+              </button>
+            </div>
+          </section>
+
+          {/* Draw + controls */}
+          <section className="flex flex-col gap-4">
+            <div className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+              <h2 className="mb-3 font-roboto-slab text-lg font-black">
+                Latest draw
+              </h2>
+              <DrawDisplay draw={lastDraw} ticket={ticket} drawKey={drawKey} />
+            </div>
+
+            <div className="border-2 border-black bg-white p-4 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+              <button
+                type="button"
+                onClick={play}
+                disabled={!ready || running}
+                className="mb-3 w-full border-2 border-black bg-lime-400 px-4 py-3 font-roboto-slab text-lg font-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+              >
+                Play ({money(TICKET_PRICE)})
+              </button>
+
+              <div className="flex gap-2">
+                {BATCHES.map((b) => (
+                  <button
+                    key={b.n}
+                    type="button"
+                    onClick={() => runMany(b.n)}
+                    disabled={!ready || running}
+                    className="flex-1 border-2 border-black bg-white px-2 py-2 font-mono text-sm font-bold shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+                  >
+                    {b.label}
+                  </button>
+                ))}
+              </div>
+
+              {batch && (
+                <div className="mt-3">
+                  <div className="mb-1 flex justify-between font-mono text-xs text-black/50">
+                    <span>Drawing…</span>
+                    <span>
+                      {count(batch.done)} / {count(batch.total)}
+                    </span>
+                  </div>
+                  <div className="h-3 border-2 border-black bg-white">
+                    <div
+                      className="h-full bg-lime-400 transition-all"
+                      style={{ width: `${batchPct}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {!ready && !running && (
+                <p className="mt-3 font-mono text-xs text-red-600">
+                  Pick {PICK - ticket.length} more number
+                  {PICK - ticket.length === 1 ? "" : "s"} to play.
+                </p>
+              )}
+            </div>
+          </section>
+        </div>
+
+        {/* Stats */}
+        <section className="mt-6">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="font-roboto-slab text-lg font-black">Your run</h2>
+            <button
+              type="button"
+              onClick={reset}
+              disabled={running || stats.draws === 0}
+              className="border-2 border-black bg-white px-3 py-1.5 font-mono text-xs font-bold shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0"
+            >
+              Reset
+            </button>
+          </div>
+          <Stats {...stats} />
+        </section>
+
+        {/* Odds + breakdown */}
+        <section className="mt-6">
+          <h2 className="mb-3 font-roboto-slab text-lg font-black">
+            Odds &amp; prizes
+          </h2>
+          <OddsTable tierCounts={tierCounts} />
+          <p
+            className={twMerge(
+              "mt-3 font-mono text-xs text-black/40",
+              stats.draws === 0 && "opacity-60"
+            )}
+          >
+            Odds shown as published &quot;x to 1&quot;. Your wins are the real
+            results of {count(stats.draws)} simulated draw
+            {stats.draws === 1 ? "" : "s"}.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Lottery.tsx
@@ -148,7 +148,7 @@ export function Lottery() {
       className={`${display.variable} ${mono.variable} h-full overflow-y-auto text-[#f3e9d2]`}
       style={{ backgroundColor: "#08060d", backgroundImage: STAGE_BG }}
     >
-      <div className="mx-auto max-w-4xl px-4 py-10 sm:py-14">
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:py-14">
         {/* Masthead */}
         <header className="text-center">
           <div className="mb-5 flex items-center justify-center gap-3">
@@ -158,7 +158,7 @@ export function Lottery() {
             </span>
             <span className="h-px w-12 bg-gradient-to-l from-transparent to-[#e9c66a]/50" />
           </div>
-          <h1 className="font-marquee text-[clamp(2.8rem,9vw,6rem)] font-black italic leading-[0.88]">
+          <h1 className="font-marquee text-[clamp(2.1rem,8.5vw,6rem)] font-black italic leading-[0.9]">
             The{" "}
             <span className="gold-foil animate-[foil-shimmer_7s_linear_infinite]">
               Midnight
@@ -169,11 +169,11 @@ export function Lottery() {
             six numbers · one in 45,057,474 · {money(TICKET_PRICE)} a line
           </p>
 
-          <div className="mt-9">
+          <div className="mt-7 sm:mt-9">
             <div className="font-ticker text-[10px] uppercase tracking-[0.42em] text-[#f3e9d2]/40">
               tonight&rsquo;s top prize
             </div>
-            <div className="gold-foil animate-[foil-shimmer_6s_linear_infinite] font-marquee mt-1 text-[clamp(3rem,11vw,7rem)] font-black leading-none">
+            <div className="gold-foil animate-[foil-shimmer_6s_linear_infinite] font-marquee mt-1 text-[clamp(2.4rem,10vw,7rem)] font-black leading-none">
               {money(6_700_000)}
             </div>
           </div>
@@ -181,7 +181,7 @@ export function Lottery() {
 
         {/* Draw chamber */}
         <section
-          className="relative mt-12 overflow-hidden rounded-2xl border border-[#e9c66a]/25 px-6 py-9"
+          className="relative mt-8 overflow-hidden rounded-2xl border border-[#e9c66a]/25 px-4 py-7 sm:mt-12 sm:px-6 sm:py-9"
           style={{
             backgroundImage:
               "radial-gradient(120% 120% at 50% 0%, rgba(44,30,54,0.6), rgba(10,8,16,0.82))",

--- a/src/app/playgrounds/lottery/_components/Lottery/NumberPicker.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/NumberPicker.tsx
@@ -1,0 +1,43 @@
+import { twMerge } from "tailwind-merge";
+import { POOL_SIZE, PICK } from "../../_lib/lottery";
+
+interface NumberPickerProps {
+  ticket: number[];
+  onToggle: (n: number) => void;
+  disabled?: boolean;
+}
+
+const NUMBERS = Array.from({ length: POOL_SIZE }, (_, i) => i + 1);
+
+export function NumberPicker({ ticket, onToggle, disabled }: NumberPickerProps) {
+  const selected = new Set(ticket);
+  const full = ticket.length >= PICK;
+
+  return (
+    <div className="grid grid-cols-10 gap-1.5">
+      {NUMBERS.map((n) => {
+        const isSelected = selected.has(n);
+        const isDisabled = disabled || (full && !isSelected);
+        return (
+          <button
+            key={n}
+            type="button"
+            onClick={() => onToggle(n)}
+            disabled={isDisabled}
+            aria-pressed={isSelected}
+            className={twMerge(
+              "aspect-square rounded-full border-2 border-black font-mono text-xs font-bold tabular-nums transition-transform",
+              isSelected
+                ? "bg-black text-[#fffef5] shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]"
+                : "bg-white text-black hover:bg-lime-200",
+              !isDisabled && "hover:-translate-y-0.5 active:translate-y-0",
+              isDisabled && !isSelected && "opacity-30 cursor-not-allowed hover:bg-white"
+            )}
+          >
+            {n}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/NumberPicker.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/NumberPicker.tsx
@@ -1,5 +1,6 @@
 import { twMerge } from "tailwind-merge";
 import { POOL_SIZE, PICK } from "../../_lib/lottery";
+import { ballColor, INK } from "../../_lib/ballColors";
 
 interface NumberPickerProps {
   ticket: number[];
@@ -18,6 +19,7 @@ export function NumberPicker({ ticket, onToggle, disabled }: NumberPickerProps) 
       {NUMBERS.map((n) => {
         const isSelected = selected.has(n);
         const isDisabled = disabled || (full && !isSelected);
+        const c = ballColor(n);
         return (
           <button
             key={n}
@@ -26,15 +28,29 @@ export function NumberPicker({ ticket, onToggle, disabled }: NumberPickerProps) 
             disabled={isDisabled}
             aria-pressed={isSelected}
             className={twMerge(
-              "aspect-square rounded-full border-2 border-black font-mono text-xs font-bold tabular-nums transition-transform",
+              "font-ticker relative grid aspect-square place-items-center rounded-full text-[11px] font-medium tabular-nums transition-all duration-150",
               isSelected
-                ? "bg-black text-[#fffef5] shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]"
-                : "bg-white text-black hover:bg-lime-200",
-              !isDisabled && "hover:-translate-y-0.5 active:translate-y-0",
-              isDisabled && !isSelected && "opacity-30 cursor-not-allowed hover:bg-white"
+                ? "scale-105 font-bold"
+                : "border border-[#f3e9d2]/12 text-[#f3e9d2]/45 hover:-translate-y-0.5 hover:border-[#f3e9d2]/40 hover:text-[#f3e9d2]",
+              isDisabled && !isSelected && "cursor-not-allowed opacity-25 hover:translate-y-0 hover:border-[#f3e9d2]/12 hover:text-[#f3e9d2]/45"
             )}
+            style={
+              isSelected
+                ? {
+                    backgroundImage: `radial-gradient(circle at 34% 28%, ${c.from} 0%, ${c.to} 70%)`,
+                    color: INK,
+                    boxShadow: `0 2px 8px rgba(0,0,0,0.5), 0 0 12px 1px ${c.glow}`,
+                  }
+                : undefined
+            }
           >
-            {n}
+            {isSelected && (
+              <span
+                aria-hidden
+                className="pointer-events-none absolute left-[20%] top-[16%] h-[26%] w-[30%] rounded-full bg-white/70 blur-[1.5px]"
+              />
+            )}
+            <span className="relative">{n}</span>
           </button>
         );
       })}

--- a/src/app/playgrounds/lottery/_components/Lottery/OddsTable.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/OddsTable.tsx
@@ -1,0 +1,53 @@
+import { TIERS, type TierCounts } from "../../_lib/lottery";
+import { count, money } from "../../_lib/format";
+
+interface OddsTableProps {
+  tierCounts: TierCounts;
+}
+
+export function OddsTable({ tierCounts }: OddsTableProps) {
+  return (
+    <div className="overflow-x-auto border-2 border-black bg-white">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b-2 border-black font-mono text-[10px] uppercase tracking-widest text-black/50">
+            <th className="px-3 py-2 text-left font-normal">Combination</th>
+            <th className="px-3 py-2 text-right font-normal">Chance (x to 1)</th>
+            <th className="px-3 py-2 text-right font-normal">Payout</th>
+            <th className="px-3 py-2 text-right font-normal">Your wins</th>
+          </tr>
+        </thead>
+        <tbody>
+          {TIERS.map((tier) => {
+            const wins = tierCounts[tier.id];
+            return (
+              <tr
+                key={tier.id}
+                className="border-b border-black/10 last:border-b-0 font-mono tabular-nums"
+              >
+                <td className="px-3 py-2 text-left font-roboto-slab font-bold">
+                  {tier.label}
+                </td>
+                <td className="px-3 py-2 text-right text-black/70">
+                  {count(tier.chance)}
+                </td>
+                <td className="px-3 py-2 text-right text-black/70">
+                  {money(tier.payout)}
+                </td>
+                <td className="px-3 py-2 text-right font-bold">
+                  {wins > 0 ? (
+                    <span className="rounded bg-lime-300 px-1.5 py-0.5">
+                      {count(wins)}
+                    </span>
+                  ) : (
+                    <span className="text-black/30">0</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/OddsTable.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/OddsTable.tsx
@@ -7,40 +7,44 @@ interface OddsTableProps {
 
 export function OddsTable({ tierCounts }: OddsTableProps) {
   return (
-    <div className="overflow-x-auto border-2 border-black bg-white">
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr className="border-b-2 border-black font-mono text-[10px] uppercase tracking-widest text-black/50">
-            <th className="px-3 py-2 text-left font-normal">Combination</th>
-            <th className="px-3 py-2 text-right font-normal">Chance (x to 1)</th>
-            <th className="px-3 py-2 text-right font-normal">Payout</th>
-            <th className="px-3 py-2 text-right font-normal">Your wins</th>
-          </tr>
-        </thead>
+    <div className="overflow-hidden rounded-lg border border-[#e9c66a]/25 bg-[#0f0b14]/70 backdrop-blur-sm">
+      <div className="flex items-center justify-between border-b border-[#e9c66a]/20 px-5 py-3">
+        <h3 className="font-ticker text-[11px] uppercase tracking-[0.3em] text-[#e9c66a]/70">
+          Prize Structure
+        </h3>
+        <span className="font-ticker text-[10px] uppercase tracking-[0.2em] text-[#f3e9d2]/35">
+          odds · x&nbsp;to&nbsp;1
+        </span>
+      </div>
+      <table className="w-full border-collapse">
         <tbody>
           {TIERS.map((tier) => {
             const wins = tierCounts[tier.id];
             return (
               <tr
                 key={tier.id}
-                className="border-b border-black/10 last:border-b-0 font-mono tabular-nums"
+                className="border-b border-dashed border-[#f3e9d2]/10 last:border-b-0"
               >
-                <td className="px-3 py-2 text-left font-roboto-slab font-bold">
-                  {tier.label}
+                <td className="px-5 py-3 text-left">
+                  <span className="font-marquee text-base italic text-[#f3e9d2]">
+                    {tier.label}
+                  </span>
                 </td>
-                <td className="px-3 py-2 text-right text-black/70">
+                <td className="px-3 py-3 text-right font-ticker text-xs tabular-nums text-[#f3e9d2]/45">
                   {count(tier.chance)}
                 </td>
-                <td className="px-3 py-2 text-right text-black/70">
+                <td className="px-3 py-3 text-right font-ticker text-xs tabular-nums text-[#f6e3a1]/90">
                   {money(tier.payout)}
                 </td>
-                <td className="px-3 py-2 text-right font-bold">
+                <td className="px-5 py-3 text-right">
                   {wins > 0 ? (
-                    <span className="rounded bg-lime-300 px-1.5 py-0.5">
+                    <span className="gold-foil font-ticker text-sm font-bold tabular-nums">
                       {count(wins)}
                     </span>
                   ) : (
-                    <span className="text-black/30">0</span>
+                    <span className="font-ticker text-xs tabular-nums text-[#f3e9d2]/20">
+                      0
+                    </span>
                   )}
                 </td>
               </tr>

--- a/src/app/playgrounds/lottery/_components/Lottery/Stats.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Stats.tsx
@@ -8,28 +8,28 @@ export interface StatsData {
   biggestWin: number;
 }
 
-interface StatBoxProps {
+function LedgerRow({
+  label,
+  value,
+  emphasis = false,
+}: {
   label: string;
   value: string;
-  tone?: "neutral" | "good" | "bad";
-}
-
-function StatBox({ label, value, tone = "neutral" }: StatBoxProps) {
+  emphasis?: boolean;
+}) {
   return (
-    <div
-      className={twMerge(
-        "border-2 border-black px-3 py-2.5 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]",
-        tone === "good" && "bg-lime-300",
-        tone === "bad" && "bg-red-300",
-        tone === "neutral" && "bg-white"
-      )}
-    >
-      <div className="font-mono text-[10px] uppercase tracking-widest text-black/50">
+    <div className="flex items-baseline justify-between gap-4 border-b border-dashed border-[#f3e9d2]/12 py-2 last:border-b-0">
+      <span className="font-ticker text-[11px] uppercase tracking-[0.22em] text-[#f3e9d2]/45">
         {label}
-      </div>
-      <div className="font-roboto-slab text-xl font-black tabular-nums leading-tight">
+      </span>
+      <span
+        className={twMerge(
+          "font-ticker tabular-nums",
+          emphasis ? "text-sm text-[#f3e9d2]" : "text-xs text-[#f3e9d2]/75"
+        )}
+      >
         {value}
-      </div>
+      </span>
     </div>
   );
 }
@@ -37,22 +37,66 @@ function StatBox({ label, value, tone = "neutral" }: StatBoxProps) {
 export function Stats({ draws, spent, won, biggestWin }: StatsData) {
   const net = won - spent;
   const returnPct = spent > 0 ? (won / spent) * 100 : 0;
+  // The verdict only lands once you've played enough to be unambiguously down.
+  const houseWins = draws >= 20 && net < 0;
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-      <StatBox label="Tickets bought" value={count(draws)} />
-      <StatBox label="Total spent" value={money(spent)} />
-      <StatBox label="Total won" value={money(won)} />
-      <StatBox
-        label="Net"
-        value={signedMoney(net)}
-        tone={net > 0 ? "good" : net < 0 ? "bad" : "neutral"}
-      />
-      <StatBox
-        label="Return"
-        value={draws > 0 ? `${returnPct.toFixed(1)}%` : "—"}
-      />
-      <StatBox label="Biggest win" value={money(biggestWin)} />
+    <div className="relative overflow-hidden rounded-lg border border-[#e9c66a]/25 bg-[#0f0b14]/70 p-5 backdrop-blur-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-ticker text-[11px] uppercase tracking-[0.3em] text-[#e9c66a]/70">
+          The Ledger
+        </h3>
+        <span className="font-ticker text-[11px] tabular-nums text-[#f3e9d2]/40">
+          {count(draws)} {draws === 1 ? "line" : "lines"}
+        </span>
+      </div>
+
+      <div className="grid gap-x-10 gap-y-1 sm:grid-cols-2">
+        <LedgerRow label="Total staked" value={money(spent)} />
+        <LedgerRow label="Total returned" value={money(won)} />
+        <LedgerRow
+          label="Return rate"
+          value={draws > 0 ? `${returnPct.toFixed(1)}%` : "—"}
+        />
+        <LedgerRow label="Biggest win" value={money(biggestWin)} />
+      </div>
+
+      {/* The net — the whole point. */}
+      <div className="mt-5 flex items-end justify-between gap-4 border-t border-[#e9c66a]/20 pt-4">
+        <span className="font-ticker text-xs uppercase tracking-[0.28em] text-[#f3e9d2]/50">
+          Net position
+        </span>
+        <span
+          className="font-marquee text-4xl font-black italic tabular-nums leading-none sm:text-5xl"
+          style={{
+            color: net > 0 ? "#5fd99a" : net < 0 ? "#e0556a" : "#f3e9d2",
+            textShadow:
+              net < 0
+                ? "0 0 24px rgba(224,85,106,0.35)"
+                : net > 0
+                  ? "0 0 24px rgba(95,217,154,0.35)"
+                  : "none",
+          }}
+        >
+          {signedMoney(net)}
+        </span>
+      </div>
+
+      {houseWins && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-2 top-1/2 -translate-y-1/2 animate-[stamp-in_0.4s_cubic-bezier(0.2,0.8,0.3,1.2)_both]"
+        >
+          <div className="rotate-[-13deg] rounded border-[3px] border-[#e0556a]/80 px-3 py-1.5 text-center mix-blend-screen">
+            <div className="font-marquee text-lg font-black uppercase italic leading-none tracking-wide text-[#e0556a]">
+              The House
+            </div>
+            <div className="font-ticker text-[9px] uppercase tracking-[0.3em] text-[#e0556a]/90">
+              always wins
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/playgrounds/lottery/_components/Lottery/Stats.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/Stats.tsx
@@ -1,0 +1,58 @@
+import { twMerge } from "tailwind-merge";
+import { count, money, signedMoney } from "../../_lib/format";
+
+export interface StatsData {
+  draws: number;
+  spent: number;
+  won: number;
+  biggestWin: number;
+}
+
+interface StatBoxProps {
+  label: string;
+  value: string;
+  tone?: "neutral" | "good" | "bad";
+}
+
+function StatBox({ label, value, tone = "neutral" }: StatBoxProps) {
+  return (
+    <div
+      className={twMerge(
+        "border-2 border-black px-3 py-2.5 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]",
+        tone === "good" && "bg-lime-300",
+        tone === "bad" && "bg-red-300",
+        tone === "neutral" && "bg-white"
+      )}
+    >
+      <div className="font-mono text-[10px] uppercase tracking-widest text-black/50">
+        {label}
+      </div>
+      <div className="font-roboto-slab text-xl font-black tabular-nums leading-tight">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function Stats({ draws, spent, won, biggestWin }: StatsData) {
+  const net = won - spent;
+  const returnPct = spent > 0 ? (won / spent) * 100 : 0;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <StatBox label="Tickets bought" value={count(draws)} />
+      <StatBox label="Total spent" value={money(spent)} />
+      <StatBox label="Total won" value={money(won)} />
+      <StatBox
+        label="Net"
+        value={signedMoney(net)}
+        tone={net > 0 ? "good" : net < 0 ? "bad" : "neutral"}
+      />
+      <StatBox
+        label="Return"
+        value={draws > 0 ? `${returnPct.toFixed(1)}%` : "—"}
+      />
+      <StatBox label="Biggest win" value={money(biggestWin)} />
+    </div>
+  );
+}

--- a/src/app/playgrounds/lottery/_components/Lottery/index.tsx
+++ b/src/app/playgrounds/lottery/_components/Lottery/index.tsx
@@ -1,0 +1,1 @@
+export { Lottery } from "./Lottery";

--- a/src/app/playgrounds/lottery/_lib/ballColors.ts
+++ b/src/app/playgrounds/lottery/_lib/ballColors.ts
@@ -1,0 +1,24 @@
+// Jewel-toned bands keyed to the number's decile — echoing the real Lotto's
+// coloured balls, tuned for luminance against a midnight stage. `from` is the
+// bright centre of the sphere, `to` its shaded edge, `glow` the halo it throws.
+export interface BallColor {
+  from: string;
+  to: string;
+  glow: string;
+}
+
+const BANDS: BallColor[] = [
+  { from: "#8df0e4", to: "#1b9486", glow: "#41ddc8" }, // 1–9   aqua
+  { from: "#ffc1d0", to: "#cf3f68", glow: "#ff6f9b" }, // 10–19 rose
+  { from: "#ffe0a0", to: "#d28f1d", glow: "#ffc24d" }, // 20–29 amber
+  { from: "#d3bfff", to: "#6a3bd1", glow: "#a987ff" }, // 30–39 violet
+  { from: "#bdf0a6", to: "#3c9b2e", glow: "#7fe35f" }, // 40–49 verdant
+  { from: "#ffae8a", to: "#cf3d27", glow: "#ff7d54" }, // 50–59 ember
+];
+
+export const INK = "#1b1208";
+
+export function ballColor(n: number): BallColor {
+  const band = Math.min(BANDS.length - 1, Math.max(0, Math.floor((n - 1) / 10)));
+  return BANDS[band];
+}

--- a/src/app/playgrounds/lottery/_lib/fonts.ts
+++ b/src/app/playgrounds/lottery/_lib/fonts.ts
@@ -1,0 +1,19 @@
+import { Fraunces, Spline_Sans_Mono } from "next/font/google";
+
+// Fraunces: a high-contrast, slightly wonky display serif — old-money lottery
+// glamour. opsz/SOFT/WONK axes let the big marquee headings turn theatrical.
+export const display = Fraunces({
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+  axes: ["opsz", "SOFT", "WONK"],
+  variable: "--font-display",
+  display: "swap",
+});
+
+// Spline Sans Mono: the ticket-printer / ledger voice. Tabular, technical,
+// quietly distinctive.
+export const mono = Spline_Sans_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap",
+});

--- a/src/app/playgrounds/lottery/_lib/format.ts
+++ b/src/app/playgrounds/lottery/_lib/format.ts
@@ -1,0 +1,24 @@
+const gbp0 = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "GBP",
+  maximumFractionDigits: 0,
+});
+
+const num = new Intl.NumberFormat("en-GB");
+
+/** Whole-pound currency, e.g. £6,700,000. */
+export function money(value: number): string {
+  return gbp0.format(value);
+}
+
+/** Thousands-separated integer, e.g. 1,019. */
+export function count(value: number): string {
+  return num.format(value);
+}
+
+/** Compact signed currency for the net figure, e.g. −£1,420 or +£30. */
+export function signedMoney(value: number): string {
+  if (value === 0) return money(0);
+  const sign = value > 0 ? "+" : "−";
+  return `${sign}${money(Math.abs(value))}`;
+}

--- a/src/app/playgrounds/lottery/_lib/lottery.test.ts
+++ b/src/app/playgrounds/lottery/_lib/lottery.test.ts
@@ -110,6 +110,28 @@ describe("runBatch", () => {
     expect(Object.values(result.tierCounts).every((c) => c === 0)).toBe(true);
   });
 
+  it("stops on the first jackpot when asked, reporting the winning bonus", () => {
+    // zeroRng draws main [1..6] bonus 7 every time, so a [1..6] ticket jackpots
+    // immediately — the run must stop after a single draw.
+    const result = runBatch([1, 2, 3, 4, 5, 6], 1000, zeroRng, {
+      stopOnJackpot: true,
+    });
+    expect(result.draws).toBe(1);
+    expect(result.spent).toBe(2);
+    expect(result.hitJackpot).toBe(true);
+    expect(result.jackpotBonus).toBe(7);
+    expect(result.tierCounts.match6).toBe(1);
+  });
+
+  it("reports no jackpot when none lands within the count", () => {
+    const result = runBatch([10, 11, 12, 13, 14, 15], 5, zeroRng, {
+      stopOnJackpot: true,
+    });
+    expect(result.draws).toBe(5);
+    expect(result.hitJackpot).toBe(false);
+    expect(result.jackpotBonus).toBe(-1);
+  });
+
   it("roughly recovers the published 3-ball odds over many draws", () => {
     // Statistical smoke test: with real randomness, ~1 in 96.2 tickets should
     // hit 3 balls. Allow a generous band so the test is not flaky.

--- a/src/app/playgrounds/lottery/_lib/lottery.test.ts
+++ b/src/app/playgrounds/lottery/_lib/lottery.test.ts
@@ -1,0 +1,135 @@
+import {
+  prizeTier,
+  payoutFor,
+  singleDraw,
+  runBatch,
+  luckyDip,
+  PICK,
+  POOL_SIZE,
+  TIER_BY_ID,
+  type Rng,
+} from "./lottery";
+
+// An rng that always returns 0 makes shuffleDraw a no-op, so the pool stays
+// [1..59]: main = [1,2,3,4,5,6], bonus = 7. Deterministic and predictable.
+const zeroRng: Rng = () => 0;
+
+describe("prizeTier", () => {
+  it("maps match counts to tiers", () => {
+    expect(prizeTier(0, false)).toBeNull();
+    expect(prizeTier(1, false)).toBeNull();
+    expect(prizeTier(2, false)).toBe("match2");
+    expect(prizeTier(3, false)).toBe("match3");
+    expect(prizeTier(4, false)).toBe("match4");
+    expect(prizeTier(5, false)).toBe("match5");
+    expect(prizeTier(6, false)).toBe("match6");
+  });
+
+  it("promotes a 5-match to the bonus tier only when the bonus matches", () => {
+    expect(prizeTier(5, true)).toBe("match5bonus");
+    expect(prizeTier(5, false)).toBe("match5");
+  });
+
+  it("ignores the bonus ball for non-5 matches", () => {
+    expect(prizeTier(4, true)).toBe("match4");
+    expect(prizeTier(6, true)).toBe("match6");
+    expect(prizeTier(1, true)).toBeNull();
+  });
+});
+
+describe("payoutFor", () => {
+  it("returns 0 for no prize", () => {
+    expect(payoutFor(null)).toBe(0);
+  });
+
+  it("returns the tier payout", () => {
+    expect(payoutFor("match2")).toBe(2);
+    expect(payoutFor("match6")).toBe(6700000);
+    expect(payoutFor("match5bonus")).toBe(1000000);
+  });
+});
+
+describe("singleDraw", () => {
+  it("produces 6 sorted distinct main balls and a distinct bonus", () => {
+    const result = singleDraw([1, 2, 3, 4, 5, 6]);
+    expect(result.main).toHaveLength(PICK);
+    const all = new Set([...result.main, result.bonus]);
+    expect(all.size).toBe(PICK + 1);
+    for (const n of all) {
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(POOL_SIZE);
+    }
+    expect([...result.main]).toEqual([...result.main].sort((a, b) => a - b));
+  });
+
+  it("scores a full jackpot match", () => {
+    const result = singleDraw([1, 2, 3, 4, 5, 6], zeroRng);
+    expect(result.main).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(result.bonus).toBe(7);
+    expect(result.matchCount).toBe(6);
+    expect(result.tier).toBe("match6");
+    expect(result.payout).toBe(6700000);
+  });
+
+  it("scores a 5 + bonus when the sixth pick is the bonus ball", () => {
+    const result = singleDraw([1, 2, 3, 4, 5, 7], zeroRng);
+    expect(result.matchCount).toBe(5);
+    expect(result.bonusMatched).toBe(true);
+    expect(result.tier).toBe("match5bonus");
+  });
+
+  it("scores a plain 5 when the sixth pick misses entirely", () => {
+    const result = singleDraw([1, 2, 3, 4, 5, 20], zeroRng);
+    expect(result.matchCount).toBe(5);
+    expect(result.bonusMatched).toBe(false);
+    expect(result.tier).toBe("match5");
+  });
+
+  it("returns no prize for a single match", () => {
+    const result = singleDraw([1, 30, 40, 50, 55, 59], zeroRng);
+    expect(result.matchCount).toBe(1);
+    expect(result.tier).toBeNull();
+    expect(result.payout).toBe(0);
+  });
+});
+
+describe("runBatch", () => {
+  it("tallies winnings and spend across draws", () => {
+    const result = runBatch([1, 2, 3, 4, 5, 6], 10, zeroRng);
+    expect(result.draws).toBe(10);
+    expect(result.spent).toBe(20);
+    expect(result.tierCounts.match6).toBe(10);
+    expect(result.won).toBe(10 * 6700000);
+    expect(result.biggestWin).toBe(6700000);
+  });
+
+  it("records zero winnings when nothing matches", () => {
+    const result = runBatch([10, 11, 12, 13, 14, 15], 5, zeroRng);
+    expect(result.won).toBe(0);
+    expect(result.biggestWin).toBe(0);
+    expect(Object.values(result.tierCounts).every((c) => c === 0)).toBe(true);
+  });
+
+  it("roughly recovers the published 3-ball odds over many draws", () => {
+    // Statistical smoke test: with real randomness, ~1 in 96.2 tickets should
+    // hit 3 balls. Allow a generous band so the test is not flaky.
+    const result = runBatch([1, 2, 3, 4, 5, 6], 200000);
+    const rate = result.tierCounts.match3 / result.draws;
+    const expected = 1 / (TIER_BY_ID.match3.chance + 1);
+    expect(rate).toBeGreaterThan(expected * 0.6);
+    expect(rate).toBeLessThan(expected * 1.6);
+  });
+});
+
+describe("luckyDip", () => {
+  it("returns 6 distinct sorted numbers in range", () => {
+    const picks = luckyDip();
+    expect(picks).toHaveLength(PICK);
+    expect(new Set(picks).size).toBe(PICK);
+    expect([...picks]).toEqual([...picks].sort((a, b) => a - b));
+    for (const n of picks) {
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(POOL_SIZE);
+    }
+  });
+});

--- a/src/app/playgrounds/lottery/_lib/lottery.ts
+++ b/src/app/playgrounds/lottery/_lib/lottery.ts
@@ -1,0 +1,169 @@
+// UK National Lottery (Lotto) rules and prize structure.
+//
+// Players pick 6 numbers from 1-59. Each draw produces 6 main balls plus a
+// single bonus ball. You win based on how many of your picks match the 6 main
+// balls; the bonus ball only matters at the 5-match tier, promoting it to the
+// "5 + bonus" prize. Odds and payouts come from the reference table.
+
+export const TICKET_PRICE = 2;
+export const POOL_SIZE = 59;
+export const PICK = 6;
+
+export type Rng = () => number;
+
+export type TierId =
+  | "match2"
+  | "match3"
+  | "match4"
+  | "match5"
+  | "match5bonus"
+  | "match6";
+
+export interface Tier {
+  id: TierId;
+  label: string;
+  /** Published odds expressed as "x to 1". */
+  chance: number;
+  payout: number;
+}
+
+// Ordered worst-to-best so tables read naturally.
+export const TIERS: Tier[] = [
+  { id: "match2", label: "2 balls", chance: 9, payout: 2 },
+  { id: "match3", label: "3 balls", chance: 95, payout: 30 },
+  { id: "match4", label: "4 balls", chance: 2179, payout: 140 },
+  { id: "match5", label: "5 balls", chance: 144414, payout: 1750 },
+  { id: "match5bonus", label: "5 balls + bonus", chance: 7509578, payout: 1000000 },
+  { id: "match6", label: "6 balls", chance: 45057474, payout: 6700000 },
+];
+
+export const TIER_BY_ID: Record<TierId, Tier> = TIERS.reduce(
+  (acc, tier) => {
+    acc[tier.id] = tier;
+    return acc;
+  },
+  {} as Record<TierId, Tier>
+);
+
+/** Maps a match outcome to its prize tier, or null for nothing. */
+export function prizeTier(matchCount: number, bonusMatched: boolean): TierId | null {
+  if (matchCount === 6) return "match6";
+  if (matchCount === 5) return bonusMatched ? "match5bonus" : "match5";
+  if (matchCount === 4) return "match4";
+  if (matchCount === 3) return "match3";
+  if (matchCount === 2) return "match2";
+  return null;
+}
+
+export function payoutFor(tier: TierId | null): number {
+  return tier ? TIER_BY_ID[tier].payout : 0;
+}
+
+function makePool(): number[] {
+  const pool = new Array<number>(POOL_SIZE);
+  for (let i = 0; i < POOL_SIZE; i++) pool[i] = i + 1;
+  return pool;
+}
+
+// Partial Fisher-Yates: uniformly randomises the first PICK+1 slots of `pool`
+// in place. Running it repeatedly on the same permuted array stays uniform, so
+// the pool can be reused across a whole batch without reallocating.
+function shuffleDraw(pool: number[], rng: Rng): void {
+  for (let i = 0; i <= PICK; i++) {
+    const j = i + Math.floor(rng() * (POOL_SIZE - i));
+    const tmp = pool[i];
+    pool[i] = pool[j];
+    pool[j] = tmp;
+  }
+}
+
+export interface DrawResult {
+  /** The 6 main balls, sorted ascending. */
+  main: number[];
+  bonus: number;
+  matchCount: number;
+  bonusMatched: boolean;
+  tier: TierId | null;
+  payout: number;
+}
+
+/** Draws a single game and evaluates it against the ticket. */
+export function singleDraw(ticket: number[], rng: Rng = Math.random): DrawResult {
+  const pool = makePool();
+  shuffleDraw(pool, rng);
+  const main = pool.slice(0, PICK).sort((a, b) => a - b);
+  const bonus = pool[PICK];
+
+  const set = new Set(ticket);
+  let matchCount = 0;
+  for (const n of main) if (set.has(n)) matchCount++;
+  const bonusMatched = set.has(bonus);
+
+  const tier = prizeTier(matchCount, bonusMatched);
+  return { main, bonus, matchCount, bonusMatched, tier, payout: payoutFor(tier) };
+}
+
+export type TierCounts = Record<TierId, number>;
+
+export function emptyTierCounts(): TierCounts {
+  return {
+    match2: 0,
+    match3: 0,
+    match4: 0,
+    match5: 0,
+    match5bonus: 0,
+    match6: 0,
+  };
+}
+
+export interface BatchResult {
+  draws: number;
+  spent: number;
+  won: number;
+  tierCounts: TierCounts;
+  /** Largest single payout seen in this batch, 0 if no wins. */
+  biggestWin: number;
+}
+
+// Runs `count` draws against a fixed ticket as fast as possible: a reused pool,
+// a lookup table for ticket membership, and no per-draw allocations.
+export function runBatch(
+  ticket: number[],
+  count: number,
+  rng: Rng = Math.random
+): BatchResult {
+  const inTicket = new Uint8Array(POOL_SIZE + 1);
+  for (const n of ticket) inTicket[n] = 1;
+
+  const pool = makePool();
+  const tierCounts = emptyTierCounts();
+  let won = 0;
+  let biggestWin = 0;
+
+  for (let d = 0; d < count; d++) {
+    shuffleDraw(pool, rng);
+    let m = 0;
+    for (let i = 0; i < PICK; i++) m += inTicket[pool[i]];
+    const tier = prizeTier(m, inTicket[pool[PICK]] === 1);
+    if (tier) {
+      tierCounts[tier]++;
+      const payout = TIER_BY_ID[tier].payout;
+      won += payout;
+      if (payout > biggestWin) biggestWin = payout;
+    }
+  }
+
+  return { draws: count, spent: count * TICKET_PRICE, won, tierCounts, biggestWin };
+}
+
+/** Picks 6 distinct numbers at random, sorted ascending. */
+export function luckyDip(rng: Rng = Math.random): number[] {
+  const pool = makePool();
+  for (let i = 0; i < PICK; i++) {
+    const j = i + Math.floor(rng() * (POOL_SIZE - i));
+    const tmp = pool[i];
+    pool[i] = pool[j];
+    pool[j] = tmp;
+  }
+  return pool.slice(0, PICK).sort((a, b) => a - b);
+}

--- a/src/app/playgrounds/lottery/_lib/lottery.ts
+++ b/src/app/playgrounds/lottery/_lib/lottery.ts
@@ -123,14 +123,26 @@ export interface BatchResult {
   tierCounts: TierCounts;
   /** Largest single payout seen in this batch, 0 if no wins. */
   biggestWin: number;
+  /** True if a 6-ball jackpot landed (and the run stopped, when requested). */
+  hitJackpot: boolean;
+  /** The bonus ball of the jackpot draw; -1 if no jackpot landed. */
+  jackpotBonus: number;
 }
 
-// Runs `count` draws against a fixed ticket as fast as possible: a reused pool,
-// a lookup table for ticket membership, and no per-draw allocations.
+export interface BatchOptions {
+  /** Stop the moment a 6-ball jackpot lands, instead of running the full count. */
+  stopOnJackpot?: boolean;
+}
+
+// Runs up to `count` draws against a fixed ticket as fast as possible: a reused
+// pool, a lookup table for ticket membership, and no per-draw allocations.
+// With `stopOnJackpot`, it returns early on the first jackpot — `draws` then
+// reflects how many were actually played, so spend stays accurate.
 export function runBatch(
   ticket: number[],
   count: number,
-  rng: Rng = Math.random
+  rng: Rng = Math.random,
+  opts: BatchOptions = {}
 ): BatchResult {
   const inTicket = new Uint8Array(POOL_SIZE + 1);
   for (const n of ticket) inTicket[n] = 1;
@@ -139,6 +151,9 @@ export function runBatch(
   const tierCounts = emptyTierCounts();
   let won = 0;
   let biggestWin = 0;
+  let drawsPlayed = count;
+  let hitJackpot = false;
+  let jackpotBonus = -1;
 
   for (let d = 0; d < count; d++) {
     shuffleDraw(pool, rng);
@@ -150,10 +165,26 @@ export function runBatch(
       const payout = TIER_BY_ID[tier].payout;
       won += payout;
       if (payout > biggestWin) biggestWin = payout;
+      if (tier === "match6") {
+        hitJackpot = true;
+        jackpotBonus = pool[PICK];
+        if (opts.stopOnJackpot) {
+          drawsPlayed = d + 1;
+          break;
+        }
+      }
     }
   }
 
-  return { draws: count, spent: count * TICKET_PRICE, won, tierCounts, biggestWin };
+  return {
+    draws: drawsPlayed,
+    spent: drawsPlayed * TICKET_PRICE,
+    won,
+    tierCounts,
+    biggestWin,
+    hitJackpot,
+    jackpotBonus,
+  };
 }
 
 /** Picks 6 distinct numbers at random, sorted ascending. */

--- a/src/app/playgrounds/lottery/opengraph-image.tsx
+++ b/src/app/playgrounds/lottery/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Lottery Simulator";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Lottery Simulator",
+  "Play the UK Lotto at £2 a ticket. Pick 6 from 59 and watch the house always win."
+);

--- a/src/app/playgrounds/lottery/page.tsx
+++ b/src/app/playgrounds/lottery/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { Lottery } from "./_components/Lottery";
+
+export const metadata: Metadata = {
+  title: "Lottery Simulator | Playground",
+  description:
+    "Play the UK Lotto at £2 a ticket. Pick 6 from 59, run a million draws, and watch the house always win.",
+  openGraph: {
+    title: "Lottery Simulator",
+    description:
+      "Play the UK Lotto at £2 a ticket. Pick 6 from 59, run a million draws, and watch the house always win.",
+  },
+};
+
+export default function LotteryPage() {
+  return <Lottery />;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -69,6 +69,12 @@
   50% { box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55), 0 0 26px 4px var(--ball-glow); }
 }
 
+/* Indeterminate progress sweep for the open-ended jackpot chase. */
+@keyframes chase-bar {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(520%); }
+}
+
 /* The verdict stamp slamming down. */
 @keyframes stamp-in {
   0% { opacity: 0; transform: rotate(-13deg) scale(2.4); }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,3 +17,9 @@
   0%, 100% { opacity: 0; }
   50% { opacity: 1; }
 }
+
+@keyframes ball-pop {
+  0% { opacity: 0; transform: scale(0.3) translateY(-8px); }
+  70% { transform: scale(1.12); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -23,3 +23,55 @@
   70% { transform: scale(1.12); }
   100% { opacity: 1; transform: scale(1) translateY(0); }
 }
+
+/* --- Lottery: "The Midnight Draw" --- */
+
+@utility font-marquee {
+  font-family: var(--font-display), "Times New Roman", Georgia, serif;
+}
+
+@utility font-ticker {
+  font-family: var(--font-mono), ui-monospace, "SFMono-Regular", monospace;
+}
+
+/* Animated gold-leaf text fill. */
+@utility gold-foil {
+  background-image: linear-gradient(
+    100deg,
+    #f7e7ad 0%,
+    #d8b24a 24%,
+    #fff6d8 46%,
+    #c69a2f 64%,
+    #f7e7ad 100%
+  );
+  background-size: 220% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+@keyframes foil-shimmer {
+  to { background-position: 220% center; }
+}
+
+/* A drawn ball tumbling onto the tray, with an overshoot bounce. */
+@keyframes ball-drop {
+  0% { opacity: 0; transform: translateY(-180%) scale(0.7) rotate(-10deg); }
+  55% { opacity: 1; transform: translateY(12%) scale(1.07) rotate(3deg); }
+  78% { transform: translateY(-5%) scale(0.98) rotate(-1deg); }
+  100% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
+}
+
+/* Pulsing halo on a matched ball; --ball-glow set inline per colour. */
+@keyframes ball-glow {
+  0%, 100% { box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55), 0 0 0 0 transparent; }
+  50% { box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55), 0 0 26px 4px var(--ball-glow); }
+}
+
+/* The verdict stamp slamming down. */
+@keyframes stamp-in {
+  0% { opacity: 0; transform: rotate(-13deg) scale(2.4); }
+  60% { opacity: 0.95; transform: rotate(-13deg) scale(0.92); }
+  100% { opacity: 0.92; transform: rotate(-13deg) scale(1); }
+}


### PR DESCRIPTION
## Why

A new playground that drives home how lopsided the UK Lotto really is. You buy £2 tickets, pick 6 from 59, and the simulator draws against the published odds — then lets you fast-forward through a million draws to watch the net loss pile up. It turns an abstract "1 in 45,057,474" into a number you feel.

## How to review

Suggested order:

1. **`_lib/lottery.ts`** — the core: draw, prize-tier mapping, batch runner. The most important file.
2. **`_lib/lottery.test.ts`** — 14 tests covering tier mapping, single draws, batch tallies, and a statistical smoke test.
3. **`_components/Lottery/Lottery.tsx`** — the container wiring state, single play, and chunked batch runs.
4. The smaller presentational components (`Ball`, `NumberPicker`, `DrawDisplay`, `OddsTable`, `Stats`) can be skimmed — they're straightforward Tailwind.
5. `page.tsx`, `Preview.tsx`, `opengraph-image.tsx`, and the homepage/globals edits are boilerplate matching existing playground conventions.

## Where to scrutinise

- **Confident in:** the lottery maths and prize logic — traced through and covered by deterministic tests (a zero-returning RNG makes draws fully predictable). The bonus ball correctly only promotes a 5-match to the £1M tier.
- **Less sure about:** the **fixed default ticket** decision (`Lottery.tsx`). I dropped a random-on-mount ticket because it tripped the repo's `set-state-in-effect` lint rule and risked an SSR hydration mismatch. The alternative is a lazy `useState(() => luckyDip())` with `suppressHydrationWarning`. Worth challenging which is preferable.
- Also worth a look: the **chunked batch loop** (50k draws/frame via rAF) — check the progress accounting and that cancellation on unmount is sound.

## Safety

Safe — purely additive. A new self-contained playground route plus one new entry on the homepage grid and one new `@keyframes` in globals. No existing behaviour changes.

## Test plan

- Open `/playgrounds/lottery`. Pick 6 numbers (or Lucky Dip), press **Play** — confirm balls animate in, matches highlight, and the win/no-win banner is correct.
- Hit **×1M** — confirm the progress bar animates smoothly, stats climb, and the net goes deeply negative.
- Try to play with fewer than 6 numbers selected — confirm Play is disabled and the "pick N more" hint shows.
- **Reset** mid-run state and confirm stats/breakdown clear but the ticket stays.
- Check mobile width: number grid, stat boxes, and odds table should remain usable.

## Out of scope / follow-ups

- No persistence — stats reset on reload.
- Manual number entry is grid-only (no typing a number).
- Random initial ticket could be revisited (see "Where to scrutinise").

🤖 Generated with [Claude Code](https://claude.com/claude-code)