### PR TITLE
feat: add "Recall" memory matching game

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import { TetrisAIPreview } from "./playgrounds/tetris-ai/Preview";
 import { BoidsPreview } from "./playgrounds/boids/Preview";
 import { ThreeBodyPreview } from "./playgrounds/three-body/Preview";
 import { LotteryPreview } from "./playgrounds/lottery/Preview";
+import { MemoryPreview } from "./playgrounds/memory/Preview";
 
 const playgrounds = [
   {
@@ -158,6 +159,14 @@ const playgrounds = [
       "Play the UK Lotto at £2 a ticket. Run a million draws and watch the house always win.",
     href: "/playgrounds/lottery",
     preview: LotteryPreview,
+  },
+  {
+    id: "memory",
+    title: "Recall",
+    description:
+      "A memory matching game. Flip cards, find the pairs, beat your best across three difficulties.",
+    href: "/playgrounds/memory",
+    preview: MemoryPreview,
   },
 ];
 

--- a/src/app/playgrounds/memory/Preview.tsx
+++ b/src/app/playgrounds/memory/Preview.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useIntersectionObserver } from "../../_hooks";
+import { ShapeIcon, type ShapeKey } from "./_lib/icons";
+
+// A fixed mini-board; two cells flip on a loop to hint at the mechanic.
+const CELLS: ShapeKey[] = ["star", "heart", "bolt", "diamond", "ring", "triangle"];
+const FLIPPERS = [1, 4];
+
+export function MemoryPreview() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver(containerRef);
+  const [flipped, setFlipped] = useState(false);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const id = setInterval(() => setFlipped((f) => !f), 1400);
+    return () => clearInterval(id);
+  }, [isVisible]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-full w-full items-center justify-center bg-[#fffef5] p-4"
+      style={{
+        backgroundImage: `
+          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
+        `,
+        backgroundSize: "20px 20px",
+      }}
+    >
+      <div className="grid grid-cols-3 gap-2">
+        {CELLS.map((shape, i) => {
+          const faceUp = FLIPPERS.includes(i) ? flipped : i % 2 === 0;
+          return (
+            <div key={i} className="h-12 w-12 [perspective:600px]">
+              <div
+                className="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d]"
+                style={{ transform: faceUp ? "rotateY(180deg)" : "rotateY(0deg)" }}
+              >
+                <div className="absolute inset-0 flex items-center justify-center rounded-md border-2 border-black bg-black text-[#fffef5] [backface-visibility:hidden]">
+                  <span className="font-roboto-slab text-lg font-black">?</span>
+                </div>
+                <div className="absolute inset-0 flex items-center justify-center rounded-md border-2 border-black bg-[#fffef5] p-2 text-black [backface-visibility:hidden] [transform:rotateY(180deg)]">
+                  <ShapeIcon shape={shape} className="h-full w-full" />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/memory/_components/Memory/Card.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Card.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { ShapeIcon } from "../../_lib/icons";
+import type { Card as CardType } from "../../_lib/game";
+
+interface CardProps {
+  card: CardType;
+  disabled: boolean;
+  onFlip: (id: number) => void;
+}
+
+export function Card({ card, disabled, onFlip }: CardProps) {
+  const faceUp = card.isFlipped || card.isMatched;
+
+  return (
+    <button
+      type="button"
+      aria-label={faceUp ? `${card.shape} card` : "hidden card"}
+      disabled={disabled || faceUp}
+      onClick={() => onFlip(card.id)}
+      className="group relative aspect-square w-full [perspective:900px] disabled:cursor-default enabled:cursor-pointer"
+    >
+      <div
+        className="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d]"
+        style={{ transform: faceUp ? "rotateY(180deg)" : "rotateY(0deg)" }}
+      >
+        {/* Back (face down) */}
+        <div className="absolute inset-0 [backface-visibility:hidden]">
+          <div className="flex h-full w-full items-center justify-center rounded-lg border-[3px] border-black bg-black text-[#fffef5] transition-transform duration-150 group-enabled:group-hover:-translate-y-1 group-enabled:group-hover:shadow-[0_6px_0_rgba(0,0,0,0.25)]">
+            <span className="font-roboto-slab text-[clamp(1.5rem,5vw,2.5rem)] font-black leading-none opacity-90">
+              ?
+            </span>
+          </div>
+        </div>
+
+        {/* Front (face up) */}
+        <div className="absolute inset-0 [backface-visibility:hidden] [transform:rotateY(180deg)]">
+          <div
+            className={`flex h-full w-full items-center justify-center rounded-lg border-[3px] p-[15%] transition-colors duration-300 ${
+              card.isMatched
+                ? "border-[#ef3d2f] bg-[#ef3d2f] text-[#fffef5]"
+                : "border-black bg-[#fffef5] text-black"
+            }`}
+          >
+            <ShapeIcon
+              shape={card.shape}
+              className={`h-full w-full ${
+                card.isMatched ? "animate-[matchpop_0.4s_ease-out]" : ""
+              }`}
+            />
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/app/playgrounds/memory/_components/Memory/Memory.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Memory.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import {
+  DIFFICULTIES,
+  buildDeck,
+  createInitialState,
+  gameReducer,
+  type Difficulty,
+} from "../../_lib/game";
+import { useBestScore } from "../../_lib/useBestScore";
+import { Card } from "./Card";
+
+const GRID_CLASS: Record<Difficulty, string> = {
+  easy: "grid-cols-3 sm:grid-cols-4",
+  medium: "grid-cols-4 sm:grid-cols-5",
+  hard: "grid-cols-5 sm:grid-cols-6",
+};
+
+const ORDER: Difficulty[] = ["easy", "medium", "hard"];
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function Memory() {
+  const [difficulty, setDifficulty] = useState<Difficulty>("easy");
+  const [state, dispatch] = useReducer(
+    gameReducer,
+    "easy",
+    createInitialState,
+  );
+
+  const [elapsed, setElapsed] = useState(0);
+  const [newBest, setNewBest] = useState(false);
+  const { best, saveIfBest } = useBestScore(difficulty);
+  const startRef = useRef<number | null>(null);
+  const savedRef = useRef(false);
+
+  const started = state.moves > 0 || state.firstPick !== null;
+  const { pairs } = DIFFICULTIES[state.difficulty];
+
+  const newGame = useCallback((d: Difficulty) => {
+    startRef.current = null;
+    savedRef.current = false;
+    setElapsed(0);
+    setNewBest(false);
+    setDifficulty(d);
+    dispatch({ type: "NEW_GAME", difficulty: d, cards: buildDeck(d) });
+  }, []);
+
+  // Clock: ticks from the first flip until the board is won.
+  useEffect(() => {
+    if (!started || state.status === "won") return;
+    if (startRef.current === null) {
+      startRef.current = Date.now() - elapsed * 1000;
+    }
+    const id = window.setInterval(() => {
+      if (startRef.current !== null) {
+        setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+      }
+    }, 250);
+    return () => window.clearInterval(id);
+  }, [started, state.status, elapsed]);
+
+  // Flip a mismatched pair back after a beat so the player can read it.
+  useEffect(() => {
+    if (state.firstPick !== null && state.secondPick !== null) {
+      const id = window.setTimeout(
+        () => dispatch({ type: "CLEAR_MISMATCH" }),
+        850,
+      );
+      return () => window.clearTimeout(id);
+    }
+  }, [state.firstPick, state.secondPick]);
+
+  // Win: fire confetti and record a personal best.
+  useEffect(() => {
+    if (state.status !== "won" || savedRef.current) return;
+    savedRef.current = true;
+
+    const record = saveIfBest({ moves: state.moves, time: elapsed });
+
+    import("canvas-confetti").then(({ default: confetti }) => {
+      const burst = (x: number) =>
+        confetti({
+          particleCount: 90,
+          spread: 75,
+          startVelocity: 45,
+          origin: { x, y: 0.65 },
+          colors: ["#000000", "#ef3d2f", "#f7c948", "#fffef5"],
+        });
+      burst(0.25);
+      burst(0.75);
+      window.setTimeout(() => burst(0.5), 250);
+      setNewBest(record);
+    });
+  }, [state.status, state.moves, elapsed, saveIfBest]);
+
+  const won = state.status === "won";
+
+  return (
+    <div
+      className="min-h-full"
+      style={{
+        backgroundColor: "#fffef5",
+        backgroundImage: `
+          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
+        `,
+        backgroundSize: "32px 32px",
+      }}
+    >
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:py-12">
+        {/* Header */}
+        <header className="mb-8">
+          <div className="mb-4 h-1 bg-black" />
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-black/50">
+                match the pairs
+              </p>
+              <h1 className="font-roboto-slab text-[clamp(3rem,10vw,5.5rem)] font-black leading-[0.85] tracking-tight text-black">
+                Recall
+              </h1>
+            </div>
+
+            {/* Difficulty selector */}
+            <div className="flex overflow-hidden rounded-md border-[3px] border-black">
+              {ORDER.map((d) => {
+                const active = difficulty === d;
+                return (
+                  <button
+                    key={d}
+                    type="button"
+                    onClick={() => newGame(d)}
+                    className={`px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors sm:px-4 ${
+                      active
+                        ? "bg-black text-[#fffef5]"
+                        : "bg-transparent text-black hover:bg-black/10"
+                    } ${d !== "easy" ? "border-l-[3px] border-black" : ""}`}
+                  >
+                    {DIFFICULTIES[d].label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </header>
+
+        {/* Stat bar */}
+        <div className="mb-6 grid grid-cols-3 gap-px overflow-hidden rounded-md border-[3px] border-black bg-black">
+          <Stat label="Moves" value={String(state.moves)} />
+          <Stat label="Time" value={formatTime(elapsed)} />
+          <Stat label="Pairs" value={`${state.matched} / ${pairs}`} />
+        </div>
+
+        {/* Board */}
+        <div className="relative">
+          <div
+            className={`grid gap-2 sm:gap-3 ${GRID_CLASS[state.difficulty]} ${
+              won ? "pointer-events-none" : ""
+            }`}
+          >
+            {state.cards.map((card, i) => (
+              <div
+                key={card.id}
+                style={{
+                  animation: "deal-in 0.4s ease-out both",
+                  animationDelay: `${Math.min(i * 25, 500)}ms`,
+                }}
+              >
+                <Card card={card} disabled={state.locked} onFlip={(id) => dispatch({ type: "FLIP", id })} />
+              </div>
+            ))}
+          </div>
+
+          {/* Win overlay */}
+          {won && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center p-4">
+              <div
+                className="w-full max-w-sm rounded-lg border-[3px] border-black bg-[#fffef5] p-6 text-center shadow-[8px_8px_0_rgba(0,0,0,1)]"
+                style={{ animation: "matchpop 0.35s ease-out" }}
+              >
+                <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-[#ef3d2f]">
+                  cleared
+                </p>
+                <h2 className="mb-3 font-roboto-slab text-4xl font-black leading-none text-black">
+                  Total Recall
+                </h2>
+                <p className="mb-4 font-mono text-sm text-black/70">
+                  {state.moves} moves · {formatTime(elapsed)}
+                  {newBest && (
+                    <span className="ml-1 text-[#ef3d2f]">· new best!</span>
+                  )}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => newGame(state.difficulty)}
+                  className="w-full rounded-md border-[3px] border-black bg-black px-4 py-3 font-mono text-xs uppercase tracking-widest text-[#fffef5] transition-transform hover:-translate-y-0.5"
+                >
+                  Play again
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer controls */}
+        <div className="mt-6 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => newGame(state.difficulty)}
+            className="rounded-md border-[3px] border-black bg-transparent px-4 py-2 font-mono text-xs uppercase tracking-widest text-black transition-colors hover:bg-black hover:text-[#fffef5]"
+          >
+            New deal
+          </button>
+          <p className="font-mono text-[11px] uppercase tracking-widest text-black/50">
+            {best ? `best: ${best.moves} moves · ${formatTime(best.time)}` : "no record yet"}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-[#fffef5] px-3 py-3 text-center sm:py-4">
+      <div className="font-mono text-[10px] uppercase tracking-[0.25em] text-black/50">
+        {label}
+      </div>
+      <div className="font-roboto-slab text-2xl font-black leading-tight text-black sm:text-3xl">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/memory/_components/Memory/index.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/index.tsx
@@ -1,0 +1,1 @@
+export { Memory } from "./Memory";

--- a/src/app/playgrounds/memory/_lib/game.test.ts
+++ b/src/app/playgrounds/memory/_lib/game.test.ts
@@ -1,0 +1,161 @@
+import {
+  DIFFICULTIES,
+  buildDeck,
+  createInitialState,
+  gameReducer,
+  shuffle,
+  type Card,
+  type Difficulty,
+  type GameState,
+} from "./game";
+
+// Deterministic RNG so decks and shuffles are reproducible in tests.
+function seededRng(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 4294967296;
+    return s / 4294967296;
+  };
+}
+
+// Build a small controllable state directly rather than through buildDeck,
+// so we can assert on known shapes.
+function stateWith(cards: Card[], difficulty: Difficulty = "easy"): GameState {
+  return {
+    difficulty,
+    cards,
+    firstPick: null,
+    secondPick: null,
+    moves: 0,
+    matched: 0,
+    status: "playing",
+    locked: false,
+  };
+}
+
+describe("shuffle", () => {
+  it("preserves all elements", () => {
+    const input = [1, 2, 3, 4, 5];
+    const result = shuffle(input, seededRng(1));
+    expect([...result].sort()).toEqual(input);
+  });
+
+  it("does not mutate the input", () => {
+    const input = [1, 2, 3];
+    shuffle(input, seededRng(1));
+    expect(input).toEqual([1, 2, 3]);
+  });
+});
+
+describe("buildDeck", () => {
+  it.each(["easy", "medium", "hard"] as const)(
+    "produces the right number of cards for %s",
+    (difficulty) => {
+      const deck = buildDeck(difficulty, seededRng(7));
+      expect(deck).toHaveLength(DIFFICULTIES[difficulty].pairs * 2);
+    },
+  );
+
+  it("contains exactly two of each shape", () => {
+    const deck = buildDeck("medium", seededRng(7));
+    const counts = new Map<string, number>();
+    for (const card of deck) {
+      counts.set(card.shape, (counts.get(card.shape) ?? 0) + 1);
+    }
+    expect(counts.size).toBe(DIFFICULTIES.medium.pairs);
+    for (const count of counts.values()) {
+      expect(count).toBe(2);
+    }
+  });
+
+  it("assigns unique sequential ids and starts face down", () => {
+    const deck = buildDeck("easy", seededRng(3));
+    expect(deck.map((c) => c.id)).toEqual(deck.map((_, i) => i));
+    expect(deck.every((c) => !c.isFlipped && !c.isMatched)).toBe(true);
+  });
+});
+
+describe("gameReducer", () => {
+  const twoPairs: Card[] = [
+    { id: 0, shape: "star", isFlipped: false, isMatched: false },
+    { id: 1, shape: "heart", isFlipped: false, isMatched: false },
+    { id: 2, shape: "star", isFlipped: false, isMatched: false },
+    { id: 3, shape: "heart", isFlipped: false, isMatched: false },
+  ];
+
+  it("flips the first card without scoring a move", () => {
+    const next = gameReducer(stateWith(twoPairs), { type: "FLIP", id: 0 });
+    expect(next.firstPick).toBe(0);
+    expect(next.moves).toBe(0);
+    expect(next.cards[0].isFlipped).toBe(true);
+  });
+
+  it("matches a pair and clears the picks", () => {
+    let state = stateWith(twoPairs);
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    state = gameReducer(state, { type: "FLIP", id: 2 });
+    expect(state.moves).toBe(1);
+    expect(state.matched).toBe(1);
+    expect(state.firstPick).toBeNull();
+    expect(state.secondPick).toBeNull();
+    expect(state.locked).toBe(false);
+    expect(state.cards[0].isMatched).toBe(true);
+    expect(state.cards[2].isMatched).toBe(true);
+  });
+
+  it("locks on a mismatch and unlocks on CLEAR_MISMATCH", () => {
+    let state = stateWith(twoPairs);
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    state = gameReducer(state, { type: "FLIP", id: 1 });
+    expect(state.locked).toBe(true);
+    expect(state.moves).toBe(1);
+    expect(state.matched).toBe(0);
+
+    // Clicks are ignored while locked.
+    const blocked = gameReducer(state, { type: "FLIP", id: 3 });
+    expect(blocked).toBe(state);
+
+    state = gameReducer(state, { type: "CLEAR_MISMATCH" });
+    expect(state.locked).toBe(false);
+    expect(state.firstPick).toBeNull();
+    expect(state.cards[0].isFlipped).toBe(false);
+    expect(state.cards[1].isFlipped).toBe(false);
+  });
+
+  it("ignores clicks on an already-flipped or matched card", () => {
+    let state = stateWith(twoPairs);
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    expect(gameReducer(state, { type: "FLIP", id: 0 })).toBe(state);
+  });
+
+  it("transitions to won when the last pair is matched", () => {
+    let state = stateWith(twoPairs);
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    state = gameReducer(state, { type: "FLIP", id: 2 });
+    state = gameReducer(state, { type: "FLIP", id: 1 });
+    state = gameReducer(state, { type: "FLIP", id: 3 });
+    expect(state.matched).toBe(2);
+    expect(state.status).toBe("won");
+  });
+
+  it("ignores flips once the game is won", () => {
+    const won: GameState = { ...stateWith(twoPairs), status: "won" };
+    expect(gameReducer(won, { type: "FLIP", id: 0 })).toBe(won);
+  });
+
+  it("resets everything on NEW_GAME", () => {
+    let state = createInitialState("easy", seededRng(1));
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    const deck = buildDeck("hard", seededRng(2));
+    const next = gameReducer(state, {
+      type: "NEW_GAME",
+      difficulty: "hard",
+      cards: deck,
+    });
+    expect(next.difficulty).toBe("hard");
+    expect(next.cards).toBe(deck);
+    expect(next.moves).toBe(0);
+    expect(next.firstPick).toBeNull();
+    expect(next.status).toBe("playing");
+  });
+});

--- a/src/app/playgrounds/memory/_lib/game.ts
+++ b/src/app/playgrounds/memory/_lib/game.ts
@@ -1,0 +1,169 @@
+// Pure game logic for the Recall memory game. Kept framework-free so the
+// reducer and deck builder can be unit tested without React.
+
+import { SHAPE_KEYS, type ShapeKey } from "./icons";
+
+export type Difficulty = "easy" | "medium" | "hard";
+
+export interface DifficultyConfig {
+  label: string;
+  pairs: number;
+  // Tailwind grid-template-columns count at the widest breakpoint.
+  columns: number;
+}
+
+export const DIFFICULTIES: Record<Difficulty, DifficultyConfig> = {
+  easy: { label: "Easy", pairs: 6, columns: 4 },
+  medium: { label: "Medium", pairs: 10, columns: 5 },
+  hard: { label: "Hard", pairs: 15, columns: 6 },
+};
+
+export interface Card {
+  id: number;
+  shape: ShapeKey;
+  isFlipped: boolean;
+  isMatched: boolean;
+}
+
+export interface GameState {
+  difficulty: Difficulty;
+  cards: Card[];
+  firstPick: number | null;
+  secondPick: number | null;
+  moves: number;
+  matched: number;
+  status: "playing" | "won";
+  // Locked while a mismatched pair is showing, so further clicks are ignored.
+  locked: boolean;
+}
+
+export type GameAction =
+  | { type: "NEW_GAME"; difficulty: Difficulty; cards: Card[] }
+  | { type: "FLIP"; id: number }
+  | { type: "CLEAR_MISMATCH" };
+
+// Fisher-Yates shuffle. Accepts an injectable RNG so tests stay deterministic.
+export function shuffle<T>(input: T[], rng: () => number = Math.random): T[] {
+  const arr = [...input];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+// Build a shuffled deck of `pairs` matched pairs, drawing distinct shapes.
+export function buildDeck(
+  difficulty: Difficulty,
+  rng: () => number = Math.random,
+): Card[] {
+  const { pairs } = DIFFICULTIES[difficulty];
+  const shapes = shuffle(SHAPE_KEYS, rng).slice(0, pairs);
+  const deck = shapes.flatMap((shape) => [shape, shape]);
+  return shuffle(deck, rng).map((shape, id) => ({
+    id,
+    shape,
+    isFlipped: false,
+    isMatched: false,
+  }));
+}
+
+export function createInitialState(
+  difficulty: Difficulty,
+  rng: () => number = Math.random,
+): GameState {
+  return {
+    difficulty,
+    cards: buildDeck(difficulty, rng),
+    firstPick: null,
+    secondPick: null,
+    moves: 0,
+    matched: 0,
+    status: "playing",
+    locked: false,
+  };
+}
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "NEW_GAME":
+      return {
+        difficulty: action.difficulty,
+        cards: action.cards,
+        firstPick: null,
+        secondPick: null,
+        moves: 0,
+        matched: 0,
+        status: "playing",
+        locked: false,
+      };
+
+    case "FLIP": {
+      if (state.locked || state.status === "won") return state;
+
+      const card = state.cards.find((c) => c.id === action.id);
+      if (!card || card.isMatched || card.isFlipped) return state;
+
+      const cards = state.cards.map((c) =>
+        c.id === action.id ? { ...c, isFlipped: true } : c,
+      );
+
+      // First card of the turn.
+      if (state.firstPick === null) {
+        return { ...state, cards, firstPick: action.id };
+      }
+
+      // Second card: score the turn.
+      const first = state.cards.find((c) => c.id === state.firstPick);
+      const isMatch = first?.shape === card.shape;
+      const moves = state.moves + 1;
+
+      if (isMatch) {
+        const matchedCards = cards.map((c) =>
+          c.id === state.firstPick || c.id === action.id
+            ? { ...c, isMatched: true }
+            : c,
+        );
+        const matched = state.matched + 1;
+        const won = matched === cards.length / 2;
+        return {
+          ...state,
+          cards: matchedCards,
+          firstPick: null,
+          secondPick: null,
+          moves,
+          matched,
+          status: won ? "won" : "playing",
+          locked: false,
+        };
+      }
+
+      // Mismatch: hold both face-up and lock until CLEAR_MISMATCH.
+      return {
+        ...state,
+        cards,
+        secondPick: action.id,
+        moves,
+        locked: true,
+      };
+    }
+
+    case "CLEAR_MISMATCH": {
+      const cards = state.cards.map((c) =>
+        c.id === state.firstPick || c.id === state.secondPick
+          ? { ...c, isFlipped: false }
+          : c,
+      );
+      return {
+        ...state,
+        cards,
+        firstPick: null,
+        secondPick: null,
+        locked: false,
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/app/playgrounds/memory/_lib/icons.tsx
+++ b/src/app/playgrounds/memory/_lib/icons.tsx
@@ -1,0 +1,143 @@
+// A set of bold, monochrome geometric glyphs drawn with SVG primitives.
+// Everything uses currentColor so a card can recolour its icon by setting
+// `color`. 16 shapes: enough for the 15-pair hard board with one to spare.
+
+import type { ReactElement } from "react";
+
+export type ShapeKey =
+  | "circle"
+  | "square"
+  | "triangle"
+  | "diamond"
+  | "star"
+  | "plus"
+  | "ring"
+  | "hexagon"
+  | "heart"
+  | "droplet"
+  | "bolt"
+  | "crescent"
+  | "arrow"
+  | "cross"
+  | "sun"
+  | "flower";
+
+export const SHAPE_KEYS: ShapeKey[] = [
+  "circle",
+  "square",
+  "triangle",
+  "diamond",
+  "star",
+  "plus",
+  "ring",
+  "hexagon",
+  "heart",
+  "droplet",
+  "bolt",
+  "crescent",
+  "arrow",
+  "cross",
+  "sun",
+  "flower",
+];
+
+const SHAPES: Record<ShapeKey, ReactElement> = {
+  circle: <circle cx="50" cy="50" r="33" fill="currentColor" />,
+  square: <rect x="18" y="18" width="64" height="64" rx="7" fill="currentColor" />,
+  triangle: <polygon points="50,14 87,82 13,82" fill="currentColor" />,
+  diamond: <polygon points="50,9 91,50 50,91 9,50" fill="currentColor" />,
+  star: (
+    <polygon
+      points="50,7 61,38 92,38 67,58 77,90 50,70 23,90 33,58 8,38 39,38"
+      fill="currentColor"
+    />
+  ),
+  plus: (
+    <path
+      d="M41 14 h18 v27 h27 v18 h-27 v27 h-18 v-27 h-27 v-18 h27 z"
+      fill="currentColor"
+    />
+  ),
+  ring: (
+    <circle
+      cx="50"
+      cy="50"
+      r="30"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="16"
+    />
+  ),
+  hexagon: (
+    <polygon points="50,8 86,29 86,71 50,92 14,71 14,29" fill="currentColor" />
+  ),
+  heart: (
+    <path
+      d="M50 85 C14 60 10 34 28 23 C41 15 50 24 50 33 C50 24 59 15 72 23 C90 34 86 60 50 85 Z"
+      fill="currentColor"
+    />
+  ),
+  droplet: (
+    <path
+      d="M50 10 C50 10 20 46 20 64 a30 30 0 1 0 60 0 C80 46 50 10 50 10 Z"
+      fill="currentColor"
+    />
+  ),
+  bolt: (
+    <polygon points="58,7 25,55 47,55 40,93 78,42 55,42" fill="currentColor" />
+  ),
+  crescent: (
+    <path
+      d="M66 12 a40 40 0 1 0 0 76 a30 30 0 1 1 0 -76 Z"
+      fill="currentColor"
+    />
+  ),
+  arrow: (
+    <polygon
+      points="50,9 86,48 65,48 65,91 35,91 35,48 14,48"
+      fill="currentColor"
+    />
+  ),
+  cross: (
+    <path
+      d="M28 18 L50 40 L72 18 L82 28 L60 50 L82 72 L72 82 L50 60 L28 82 L18 72 L40 50 L18 28 Z"
+      fill="currentColor"
+    />
+  ),
+  sun: (
+    <g stroke="currentColor" strokeWidth="8" strokeLinecap="round">
+      <circle cx="50" cy="50" r="17" fill="currentColor" stroke="none" />
+      <line x1="50" y1="8" x2="50" y2="22" />
+      <line x1="50" y1="78" x2="50" y2="92" />
+      <line x1="8" y1="50" x2="22" y2="50" />
+      <line x1="78" y1="50" x2="92" y2="50" />
+      <line x1="20" y1="20" x2="30" y2="30" />
+      <line x1="70" y1="70" x2="80" y2="80" />
+      <line x1="80" y1="20" x2="70" y2="30" />
+      <line x1="30" y1="70" x2="20" y2="80" />
+    </g>
+  ),
+  flower: (
+    <g fill="currentColor">
+      <circle cx="50" cy="26" r="15" />
+      <circle cx="50" cy="74" r="15" />
+      <circle cx="26" cy="50" r="15" />
+      <circle cx="74" cy="50" r="15" />
+      <circle cx="50" cy="50" r="12" fill="#fffef5" />
+    </g>
+  ),
+};
+
+export function ShapeIcon({
+  shape,
+  className,
+}: {
+  shape: ShapeKey;
+  className?: string;
+}) {
+  return (
+    <svg viewBox="0 0 100 100" className={className} aria-hidden="true">
+      {SHAPES[shape]}
+    </svg>
+  );
+}

--- a/src/app/playgrounds/memory/_lib/useBestScore.ts
+++ b/src/app/playgrounds/memory/_lib/useBestScore.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import type { Difficulty } from "./game";
+
+export interface Best {
+  moves: number;
+  time: number;
+}
+
+const key = (d: Difficulty) => `recall-best-${d}`;
+
+// Same-tab change notifications: the native `storage` event only fires in
+// other tabs, so we keep our own listener set and emit on write.
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+// getSnapshot must return a stable reference between renders or React loops,
+// so we memoise the parsed value against the raw string per difficulty.
+const cache = new Map<Difficulty, { raw: string | null; value: Best | null }>();
+
+function getSnapshot(d: Difficulty): Best | null {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(key(d));
+  } catch {
+    raw = null;
+  }
+  const cached = cache.get(d);
+  if (!cached || cached.raw !== raw) {
+    let value: Best | null = null;
+    try {
+      value = raw ? (JSON.parse(raw) as Best) : null;
+    } catch {
+      value = null;
+    }
+    cache.set(d, { raw, value });
+  }
+  return cache.get(d)!.value;
+}
+
+export function useBestScore(difficulty: Difficulty) {
+  const best = useSyncExternalStore(
+    subscribe,
+    useCallback(() => getSnapshot(difficulty), [difficulty]),
+    () => null,
+  );
+
+  // Record `score` only if it beats the stored best (fewer moves wins ties
+  // broken by time). Returns true when a new record was written.
+  const saveIfBest = useCallback(
+    (score: Best): boolean => {
+      const prev = getSnapshot(difficulty);
+      const better =
+        !prev ||
+        score.moves < prev.moves ||
+        (score.moves === prev.moves && score.time < prev.time);
+      if (better) {
+        try {
+          window.localStorage.setItem(key(difficulty), JSON.stringify(score));
+        } catch {
+          // Storage unavailable (private mode etc.); keep playing regardless.
+        }
+        listeners.forEach((l) => l());
+        return true;
+      }
+      return false;
+    },
+    [difficulty],
+  );
+
+  return { best, saveIfBest };
+}

--- a/src/app/playgrounds/memory/opengraph-image.tsx
+++ b/src/app/playgrounds/memory/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Recall";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Recall",
+  "A memory matching game. Flip cards, find the pairs, beat your best.",
+);

--- a/src/app/playgrounds/memory/page.tsx
+++ b/src/app/playgrounds/memory/page.tsx
@@ -1,0 +1,17 @@
+import { Memory } from "./_components/Memory";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Recall | Playground",
+  description:
+    "A memory matching game. Flip cards, find the pairs, beat your best. Easy, medium and hard boards.",
+  openGraph: {
+    title: "Recall",
+    description:
+      "A memory matching game. Flip cards, find the pairs, beat your best. Easy, medium and hard boards.",
+  },
+};
+
+export default function MemoryPage() {
+  return <Memory />;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,6 +24,21 @@
   100% { opacity: 1; transform: scale(1) translateY(0); }
 }
 
+/* --- Memory: "Recall" --- */
+
+/* A matched icon giving a little celebratory kick. */
+@keyframes matchpop {
+  0% { transform: scale(1); }
+  45% { transform: scale(1.28) rotate(-4deg); }
+  100% { transform: scale(1) rotate(0); }
+}
+
+/* Staggered entrance for cards on a new deal. */
+@keyframes deal-in {
+  0% { opacity: 0; transform: translateY(14px) scale(0.9); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 /* --- Lottery: "The Midnight Draw" --- */
 
 @utility font-marquee {


### PR DESCRIPTION
### What

New playground at `/playgrounds/memory`: a card-matching memory game called **Recall**.

- Three difficulties: Easy (6 pairs), Medium (10), Hard (15), via a segmented selector that reshuffles a fresh board.
- 3D card-flip animation (`rotateY` + `preserve-3d` + `backface-visibility`), staggered deal-in entrance, and a match "pop" on paired cards.
- `canvas-confetti` salute plus a win overlay on completion.
- Live timer (starts on first flip), move counter, pairs-found, and per-difficulty personal bests stored in `localStorage`.
- 16 hand-drawn monochrome SVG glyphs (no emoji) to match the site's black-on-cream brutalist look.
- Registered on the homepage grid with an animated preview.

### Why

Adds another interactive demo to the playground.

### Notes

- Game logic is a pure `useReducer` (not XState) with an injectable RNG, so the reducer and deck-builder are unit tested (14 tests). Win is keyed off `cards.length / 2` rather than the difficulty config so it can't drift.
- Best scores use `useSyncExternalStore` over `localStorage` instead of an effect-driven load, avoiding a hydration mismatch and the repo's `react-hooks/set-state-in-effect` rule.
- Verified: full test suite (55 passing), `tsc --noEmit` clean, production build compiles the route. Flip animation and confetti not yet driven in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)