### PR TITLE
feat: add "Fowl Play" chicken crossing arcade game

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import { ThreeBodyPreview } from "./playgrounds/three-body/Preview";
 import { LotteryPreview } from "./playgrounds/lottery/Preview";
 import { MemoryPreview } from "./playgrounds/memory/Preview";
 import { SimonPreview } from "./playgrounds/simon/Preview";
+import { ChickenCrossingPreview } from "./playgrounds/chicken-crossing/Preview";
 
 const playgrounds = [
   {
@@ -30,6 +31,14 @@ const playgrounds = [
       "A Simon memory game. Watch the pattern of colours and tones, then tap it back. It grows every round.",
     href: "/playgrounds/simon",
     preview: SimonPreview,
+  },
+  {
+    id: "chicken-crossing",
+    title: "Fowl Play",
+    description:
+      "Get the chicken across the road, dodge the bikes and beat the clock. Each level gets faster.",
+    href: "/playgrounds/chicken-crossing",
+    preview: ChickenCrossingPreview,
   },
   {
     id: "spirograph",

--- a/src/app/playgrounds/chicken-crossing/Preview.tsx
+++ b/src/app/playgrounds/chicken-crossing/Preview.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useIntersectionObserver } from "../../_hooks";
+import { COLS, ROWS, START_ROW, GOAL_ROW, createLevel, advanceBikes } from "./_lib/game";
+import { COLORS, drawChicken, drawBike } from "./_lib/sprites";
+
+const STEP_MS = 520; // how often the demo chicken hops
+
+export function ChickenCrossingPreview() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isVisible = useIntersectionObserver(containerRef);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d", { alpha: false });
+    if (!ctx) return;
+
+    const { width, height } = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.imageSmoothingEnabled = false;
+
+    // Fit the board to the card, centred.
+    const cell = Math.min(width / COLS, height / ROWS);
+    const boardW = cell * COLS;
+    const boardH = cell * ROWS;
+    const ox = (width - boardW) / 2;
+    const oy = (height - boardH) / 2;
+
+    const state = createLevel(3);
+    let raf = 0;
+    let last = 0;
+    let acc = 0;
+
+    const frame = (now: number) => {
+      if (!last) last = now;
+      const dt = Math.min((now - last) / 1000, 0.05);
+      last = now;
+
+      advanceBikes(state, dt);
+
+      // Auto-hop the chicken up the board on a timer; loop at the top.
+      acc += dt * 1000;
+      if (acc >= STEP_MS) {
+        acc = 0;
+        state.chicken.row -= 1;
+        if (state.chicken.row < GOAL_ROW) {
+          state.chicken.row = START_ROW;
+          state.chicken.col = 2 + Math.floor(Math.random() * (COLS - 4));
+        }
+      }
+
+      ctx.fillStyle = COLORS.road;
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.save();
+      ctx.translate(ox, oy);
+
+      for (const lane of state.lanes) {
+        const y = lane.row * cell;
+        if (lane.type === "grass") {
+          ctx.fillStyle = lane.row === 0 ? COLORS.goalGlow : COLORS.grass;
+          ctx.fillRect(0, y, boardW, cell);
+        } else {
+          ctx.fillStyle = lane.row % 2 === 0 ? COLORS.road : COLORS.roadAlt;
+          ctx.fillRect(0, y, boardW, cell);
+          ctx.fillStyle = COLORS.laneMark;
+          for (let c = 0; c < COLS; c++) {
+            if (c % 2 === 0) ctx.fillRect(c * cell + cell / 2 - 3, y + cell / 2 - 1, 6, 2);
+          }
+        }
+      }
+
+      for (const bike of state.bikes) {
+        drawBike(ctx, (bike.x + 0.5) * cell, (bike.row + 0.5) * cell, cell * 1.3, bike.row, bike.dir > 0);
+      }
+
+      drawChicken(ctx, (state.chicken.col + 0.5) * cell, (state.chicken.row + 0.5) * cell, cell);
+
+      ctx.restore();
+      raf = requestAnimationFrame(frame);
+    };
+
+    raf = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(raf);
+  }, [isVisible]);
+
+  return (
+    <div ref={containerRef} className="h-full w-full bg-[#14141c]">
+      <canvas ref={canvasRef} className="h-full w-full [image-rendering:pixelated]" />
+    </div>
+  );
+}

--- a/src/app/playgrounds/chicken-crossing/_components/ChickenCrossing/ChickenCrossing.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/ChickenCrossing/ChickenCrossing.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { GameCanvas, type Phase } from "../GameCanvas";
+import { HudBar, GameOverlay } from "../HUD";
+import { LEVEL_CLEAR_BONUS, timeBonus } from "../../_lib/game";
+import { useBestScore } from "../../_lib/useBestScore";
+
+const START_LIVES = 3;
+const DEATH_PAUSE_MS = 850;
+
+export function ChickenCrossing() {
+  const [phase, setPhase] = useState<Phase>("ready");
+  const [level, setLevel] = useState(1);
+  const [lives, setLives] = useState(START_LIVES);
+  const [score, setScore] = useState(0);
+  const [epoch, setEpoch] = useState(0);
+  const [deathReason, setDeathReason] = useState<"crash" | "time" | null>(null);
+  const [isNewBest, setIsNewBest] = useState(false);
+
+  const { best, saveIfBest } = useBestScore();
+
+  // Refs let the canvas's imperative callbacks read/update fresh values without
+  // stale closures, and drive phase-dependent branching synchronously.
+  const livesRef = useRef(START_LIVES);
+  const scoreRef = useRef(0);
+  const phaseRef = useRef<Phase>("ready");
+  useEffect(() => {
+    phaseRef.current = phase;
+  });
+
+  const startGame = useCallback(() => {
+    livesRef.current = START_LIVES;
+    scoreRef.current = 0;
+    setLives(START_LIVES);
+    setScore(0);
+    setLevel(1);
+    setDeathReason(null);
+    setIsNewBest(false);
+    setEpoch((e) => e + 1);
+    setPhase("playing");
+  }, []);
+
+  const nextLevel = useCallback(() => {
+    setLevel((l) => l + 1);
+    setEpoch((e) => e + 1);
+    setPhase("playing");
+  }, []);
+
+  const loseLife = useCallback((reason: "crash" | "time") => {
+    setDeathReason(reason);
+    const remaining = livesRef.current - 1;
+    livesRef.current = remaining;
+    setLives(remaining);
+    setPhase(remaining <= 0 ? "gameOver" : "dead");
+  }, []);
+
+  const handleScore = useCallback((points: number) => {
+    scoreRef.current += points;
+    setScore(scoreRef.current);
+  }, []);
+
+  const handleReachGoal = useCallback((timeLeft: number) => {
+    scoreRef.current += LEVEL_CLEAR_BONUS + timeBonus(timeLeft);
+    setScore(scoreRef.current);
+    setPhase("levelComplete");
+  }, []);
+
+  const handleCrash = useCallback(() => loseLife("crash"), [loseLife]);
+  const handleTimeUp = useCallback(() => loseLife("time"), [loseLife]);
+
+  // Primary action (button / space / tap) means different things per phase.
+  const handlePrimaryAction = useCallback(() => {
+    const p = phaseRef.current;
+    if (p === "ready" || p === "gameOver") startGame();
+    else if (p === "levelComplete") nextLevel();
+  }, [startGame, nextLevel]);
+
+  // After a non-fatal death, pause briefly then respawn on the same level.
+  useEffect(() => {
+    if (phase !== "dead") return;
+    const id = setTimeout(() => {
+      setEpoch((e) => e + 1);
+      setPhase("playing");
+    }, DEATH_PAUSE_MS);
+    return () => clearTimeout(id);
+  }, [phase]);
+
+  // Record the score once the run is over.
+  useEffect(() => {
+    if (phase === "gameOver") setIsNewBest(saveIfBest(scoreRef.current));
+  }, [phase, saveIfBest]);
+
+  return (
+    <div className="flex h-full flex-col bg-[#14141c] text-white">
+      <HudBar level={level} lives={lives} score={score} best={best} />
+
+      <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-2">
+        {/* CRT scanline veil, purely cosmetic. */}
+        <div
+          className="pointer-events-none absolute inset-0 z-30 opacity-30"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(0deg, rgba(0,0,0,0.5) 0px, rgba(0,0,0,0.5) 1px, transparent 1px, transparent 3px)",
+          }}
+        />
+        {/* Canvas box: height-driven so the portrait board fits the viewport. */}
+        <div className="relative h-full max-h-full">
+          <GameCanvas
+            level={level}
+            epoch={epoch}
+            phase={phase}
+            onCrash={handleCrash}
+            onReachGoal={handleReachGoal}
+            onScore={handleScore}
+            onTimeUp={handleTimeUp}
+            onPrimaryAction={handlePrimaryAction}
+          />
+          <GameOverlay
+            phase={phase}
+            level={level}
+            lives={lives}
+            score={score}
+            best={best}
+            isNewBest={isNewBest}
+            deathReason={deathReason}
+            onPrimaryAction={handlePrimaryAction}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/chicken-crossing/_components/ChickenCrossing/index.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/ChickenCrossing/index.tsx
@@ -1,0 +1,1 @@
+export { ChickenCrossing } from "./ChickenCrossing";

--- a/src/app/playgrounds/chicken-crossing/_components/GameCanvas/GameCanvas.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/GameCanvas/GameCanvas.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  COLS,
+  ROWS,
+  POINTS_PER_ROW,
+  createLevel,
+  advanceBikes,
+  tickTimer,
+  hop,
+  checkCollision,
+  atGoal,
+  type GameState,
+  type Direction,
+} from "../../_lib/game";
+import { COLORS, drawChicken, drawBike } from "../../_lib/sprites";
+
+export type Phase = "ready" | "playing" | "dead" | "levelComplete" | "gameOver";
+
+// Internal pixels per grid cell. The canvas renders at this fixed resolution
+// and is CSS-scaled up with pixelated rendering for the arcade look.
+const CELL = 22;
+const HOP_MS = 150;
+const MAX_DT = 0.05;
+
+function renderScene(
+  ctx: CanvasRenderingContext2D,
+  st: GameState,
+  now: number,
+  hopStart: number,
+) {
+  // Rows.
+  for (const lane of st.lanes) {
+    const y = lane.row * CELL;
+    if (lane.type === "grass") {
+      const isGoal = lane.row === 0;
+      ctx.fillStyle = isGoal ? COLORS.goalGlow : COLORS.grass;
+      ctx.fillRect(0, y, COLS * CELL, CELL);
+      // Grass texture: alternating darker tufts.
+      ctx.fillStyle = isGoal ? "rgba(255,255,255,0.18)" : COLORS.grassAlt;
+      for (let c = 0; c < COLS; c++) {
+        if ((c + lane.row) % 2 === 0) {
+          ctx.fillRect(c * CELL + 4, y + CELL - 6, 6, 3);
+        }
+      }
+      if (isGoal) {
+        // Checkered finish strip along the bottom of the goal row.
+        for (let c = 0; c < COLS; c++) {
+          ctx.fillStyle = c % 2 === 0 ? "#1e1e24" : "#ffffff";
+          ctx.fillRect(c * CELL, y + CELL - 5, CELL, 5);
+        }
+      }
+    } else {
+      ctx.fillStyle = lane.row % 2 === 0 ? COLORS.road : COLORS.roadAlt;
+      ctx.fillRect(0, y, COLS * CELL, CELL);
+      // Dashed centre line.
+      ctx.fillStyle = COLORS.laneMark;
+      for (let c = 0; c < COLS; c++) {
+        if (c % 2 === 0) ctx.fillRect(c * CELL + CELL / 2 - 4, y + CELL / 2 - 1, 8, 2);
+      }
+    }
+  }
+
+  // Bikes.
+  for (const bike of st.bikes) {
+    const cx = (bike.x + bike.length / 2) * CELL;
+    const cy = (bike.row + 0.5) * CELL;
+    drawBike(ctx, cx, cy, CELL * 1.35, bike.row, bike.dir > 0);
+  }
+
+  // Chicken with a brief hop squash.
+  const hopProgress = Math.max(0, 1 - (now - hopStart) / HOP_MS);
+  const chx = (st.chicken.col + 0.5) * CELL;
+  const chy = (st.chicken.row + 0.5) * CELL;
+  drawChicken(ctx, chx, chy, CELL, hopProgress);
+
+  // Timer bar across the very top.
+  const frac = st.levelDuration > 0 ? st.timeLeft / st.levelDuration : 0;
+  ctx.fillStyle = "rgba(0,0,0,0.35)";
+  ctx.fillRect(0, 0, COLS * CELL, 4);
+  ctx.fillStyle = frac < 0.25 ? "#ff5964" : "#ffd23f";
+  ctx.fillRect(0, 0, COLS * CELL * frac, 4);
+}
+
+interface Props {
+  level: number;
+  // Bumped whenever a fresh crossing should begin (new game, level up, respawn).
+  epoch: number;
+  phase: Phase;
+  onCrash: () => void;
+  onReachGoal: (timeLeft: number) => void;
+  onScore: (points: number) => void;
+  onTimeUp: () => void;
+  onPrimaryAction: () => void;
+}
+
+export function GameCanvas({
+  level,
+  epoch,
+  phase,
+  onCrash,
+  onReachGoal,
+  onScore,
+  onTimeUp,
+  onPrimaryAction,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stateRef = useRef<GameState>(createLevel(1));
+  const phaseRef = useRef<Phase>(phase);
+  const resolvedRef = useRef(false);
+  const hopStartRef = useRef(0);
+
+  // Keep the latest callbacks/phase in refs so the rAF loop never restarts.
+  const cbRef = useRef({ onCrash, onReachGoal, onScore, onTimeUp, onPrimaryAction });
+  useEffect(() => {
+    cbRef.current = { onCrash, onReachGoal, onScore, onTimeUp, onPrimaryAction };
+    phaseRef.current = phase;
+  });
+
+  // Start a fresh crossing whenever the level or epoch changes.
+  useEffect(() => {
+    stateRef.current = createLevel(level);
+    resolvedRef.current = false;
+  }, [level, epoch]);
+
+  // Single animation loop for the component's lifetime. Bikes always move (so
+  // the board stays alive under overlays); game logic only runs while playing.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d", { alpha: false });
+    if (!ctx) return;
+
+    canvas.width = COLS * CELL;
+    canvas.height = ROWS * CELL;
+
+    let raf = 0;
+    let last = 0;
+
+    const frame = (now: number) => {
+      if (!last) last = now;
+      const dt = Math.min((now - last) / 1000, MAX_DT);
+      last = now;
+
+      const st = stateRef.current;
+      advanceBikes(st, dt);
+
+      if (phaseRef.current === "playing") {
+        tickTimer(st, dt);
+        if (!resolvedRef.current) {
+          if (checkCollision(st)) {
+            resolvedRef.current = true;
+            cbRef.current.onCrash();
+          } else if (atGoal(st)) {
+            resolvedRef.current = true;
+            cbRef.current.onReachGoal(st.timeLeft);
+          } else if (st.timeLeft <= 0) {
+            resolvedRef.current = true;
+            cbRef.current.onTimeUp();
+          }
+        }
+      }
+
+      renderScene(ctx, st, now, hopStartRef.current);
+      raf = requestAnimationFrame(frame);
+    };
+
+    raf = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Keyboard: movement while playing, primary action (start/next/retry) otherwise.
+  useEffect(() => {
+    const move = (dir: Direction) => {
+      if (phaseRef.current !== "playing" || resolvedRef.current) return;
+      const gained = hop(stateRef.current, dir);
+      hopStartRef.current = performance.now();
+      if (gained > 0) cbRef.current.onScore(gained * POINTS_PER_ROW);
+    };
+
+    const onKey = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowUp":
+        case "w":
+        case "W":
+          e.preventDefault();
+          move("up");
+          break;
+        case "ArrowDown":
+        case "s":
+        case "S":
+          e.preventDefault();
+          move("down");
+          break;
+        case "ArrowLeft":
+        case "a":
+        case "A":
+          e.preventDefault();
+          move("left");
+          break;
+        case "ArrowRight":
+        case "d":
+        case "D":
+          e.preventDefault();
+          move("right");
+          break;
+        case " ":
+        case "Enter":
+          e.preventDefault();
+          if (phaseRef.current !== "playing") cbRef.current.onPrimaryAction();
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Touch: swipe to steer, tap to hop forward (or to trigger the primary action
+  // when not mid-game).
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    let sx = 0;
+    let sy = 0;
+    let stime = 0;
+
+    const move = (dir: Direction) => {
+      if (phaseRef.current !== "playing" || resolvedRef.current) return;
+      const gained = hop(stateRef.current, dir);
+      hopStartRef.current = performance.now();
+      if (gained > 0) cbRef.current.onScore(gained * POINTS_PER_ROW);
+    };
+
+    const onStart = (e: TouchEvent) => {
+      const t = e.changedTouches[0];
+      sx = t.clientX;
+      sy = t.clientY;
+      stime = performance.now();
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (phaseRef.current === "playing") e.preventDefault();
+    };
+
+    const onEnd = (e: TouchEvent) => {
+      const t = e.changedTouches[0];
+      const dx = t.clientX - sx;
+      const dy = t.clientY - sy;
+      const dist = Math.hypot(dx, dy);
+
+      if (phaseRef.current !== "playing") {
+        if (performance.now() - stime < 500) cbRef.current.onPrimaryAction();
+        return;
+      }
+
+      if (dist < 24) {
+        // Tap: hop toward where you tapped, relative to the chicken. Tap ahead
+        // to go up, tap to either side to go left/right, tap behind to go down.
+        const rect = canvas.getBoundingClientRect();
+        const tapCol = ((t.clientX - rect.left) / rect.width) * COLS;
+        const tapRow = ((t.clientY - rect.top) / rect.height) * ROWS;
+        const ch = stateRef.current.chicken;
+        const tdx = tapCol - (ch.col + 0.5);
+        const tdy = tapRow - (ch.row + 0.5);
+        if (Math.abs(tdx) > Math.abs(tdy)) {
+          move(tdx > 0 ? "right" : "left");
+        } else {
+          move(tdy > 0 ? "down" : "up");
+        }
+      } else if (Math.abs(dx) > Math.abs(dy)) {
+        move(dx > 0 ? "right" : "left");
+      } else {
+        move(dy > 0 ? "down" : "up");
+      }
+    };
+
+    canvas.addEventListener("touchstart", onStart, { passive: true });
+    canvas.addEventListener("touchmove", onMove, { passive: false });
+    canvas.addEventListener("touchend", onEnd, { passive: true });
+    return () => {
+      canvas.removeEventListener("touchstart", onStart);
+      canvas.removeEventListener("touchmove", onMove);
+      canvas.removeEventListener("touchend", onEnd);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="block h-full w-auto max-w-full touch-none rounded-sm [image-rendering:pixelated]"
+      style={{ aspectRatio: `${COLS} / ${ROWS}` }}
+    />
+  );
+}

--- a/src/app/playgrounds/chicken-crossing/_components/GameCanvas/index.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/GameCanvas/index.tsx
@@ -1,0 +1,1 @@
+export { GameCanvas, type Phase } from "./GameCanvas";

--- a/src/app/playgrounds/chicken-crossing/_components/HUD/HUD.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/HUD/HUD.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import type { Phase } from "../GameCanvas";
+
+// A tiny pixel chicken for the lives counter.
+function ChickenIcon({ dimmed = false }: { dimmed?: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 11 12"
+      className="h-4 w-4"
+      style={{ imageRendering: "pixelated", opacity: dimmed ? 0.2 : 1 }}
+      aria-hidden
+    >
+      <g shapeRendering="crispEdges">
+        <rect x="4" y="0" width="3" height="2" fill="#e23b3b" />
+        <rect x="3" y="1" width="5" height="1" fill="#e23b3b" />
+        <rect x="4" y="2" width="3" height="1" fill="#f5a623" />
+        <rect x="2" y="3" width="7" height="5" fill="#fdfdfd" />
+        <rect x="1" y="5" width="9" height="3" fill="#fdfdfd" />
+        <rect x="3" y="5" width="1" height="1" fill="#1e1e24" />
+        <rect x="7" y="5" width="1" height="1" fill="#1e1e24" />
+        <rect x="3" y="10" width="1" height="2" fill="#f5a623" />
+        <rect x="7" y="10" width="1" height="2" fill="#f5a623" />
+      </g>
+    </svg>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col leading-none">
+      <span className="font-mono text-[9px] uppercase tracking-widest text-white/40">
+        {label}
+      </span>
+      <span className="font-mono text-lg font-bold tabular-nums text-white">{value}</span>
+    </div>
+  );
+}
+
+function ArcadeButton({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="mt-4 border-2 border-[#ffd23f] bg-[#ffd23f] px-6 py-2 font-mono text-sm font-bold uppercase tracking-widest text-[#14141c] transition-transform hover:scale-105 active:scale-95"
+    >
+      {children}
+    </button>
+  );
+}
+
+const MAX_LIVES = 3;
+
+export function HudBar({
+  level,
+  lives,
+  score,
+  best,
+}: {
+  level: number;
+  lives: number;
+  score: number;
+  best: number;
+}) {
+  return (
+    <div className="flex shrink-0 items-center justify-between gap-4 border-b-2 border-white/10 px-4 py-2">
+      <div className="flex items-center gap-5">
+        <Stat label="Level" value={level} />
+        <Stat label="Score" value={score} />
+        <Stat label="Best" value={best} />
+      </div>
+      <div className="flex items-center gap-1">
+        {Array.from({ length: MAX_LIVES }, (_, i) => (
+          <ChickenIcon key={i} dimmed={i >= lives} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface OverlayProps {
+  phase: Phase;
+  level: number;
+  lives: number;
+  score: number;
+  best: number;
+  isNewBest: boolean;
+  deathReason: "crash" | "time" | null;
+  onPrimaryAction: () => void;
+}
+
+export function GameOverlay({
+  phase,
+  level,
+  lives,
+  score,
+  best,
+  isNewBest,
+  deathReason,
+  onPrimaryAction,
+}: OverlayProps) {
+  if (phase === "playing") return null;
+
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/45 p-4 text-center backdrop-blur-[1px]">
+      <div className="flex flex-col items-center">
+        {phase === "ready" && (
+          <>
+            <h1 className="font-roboto-slab text-4xl font-black text-white drop-shadow-[3px_3px_0_#e23b3b] sm:text-5xl">
+              FOWL PLAY
+            </h1>
+            <p className="mt-3 max-w-xs font-mono text-xs leading-relaxed text-white/70">
+              Get the chicken across the road. Dodge the bikes. Beat the clock.
+            </p>
+            <p className="mt-2 font-mono text-[10px] uppercase tracking-widest text-white/40">
+              Arrows / WASD / swipe · tap to hop
+            </p>
+            <ArcadeButton onClick={onPrimaryAction}>Start</ArcadeButton>
+          </>
+        )}
+
+        {phase === "dead" && (
+          <div className="rounded bg-[#e23b3b]/90 px-6 py-3">
+            <p className="font-roboto-slab text-3xl font-black text-white">
+              {deathReason === "time" ? "TIME!" : "SPLAT!"}
+            </p>
+            <p className="mt-1 font-mono text-xs uppercase tracking-widest text-white/80">
+              Lives left: {lives}
+            </p>
+          </div>
+        )}
+
+        {phase === "levelComplete" && (
+          <>
+            <p className="font-mono text-xs uppercase tracking-widest text-[#7bd66b]">
+              Made it across
+            </p>
+            <h2 className="mt-1 font-roboto-slab text-4xl font-black text-white">
+              Level {level} cleared
+            </h2>
+            <p className="mt-2 font-mono text-sm text-white/70">
+              Score: <span className="font-bold text-white">{score}</span>
+            </p>
+            <ArcadeButton onClick={onPrimaryAction}>Next level</ArcadeButton>
+          </>
+        )}
+
+        {phase === "gameOver" && (
+          <>
+            <h2 className="font-roboto-slab text-5xl font-black text-[#e23b3b] drop-shadow-[3px_3px_0_#14141c]">
+              GAME OVER
+            </h2>
+            <p className="mt-3 font-mono text-sm text-white/70">
+              Final score: <span className="font-bold text-white">{score}</span>
+            </p>
+            <p className="font-mono text-sm text-white/70">
+              Best: <span className="font-bold text-white">{best}</span>
+            </p>
+            {isNewBest && (
+              <p className="mt-2 font-mono text-xs font-bold uppercase tracking-widest text-[#ffd23f]">
+                ★ New best ★
+              </p>
+            )}
+            <ArcadeButton onClick={onPrimaryAction}>Play again</ArcadeButton>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/chicken-crossing/_components/HUD/index.tsx
+++ b/src/app/playgrounds/chicken-crossing/_components/HUD/index.tsx
@@ -1,0 +1,1 @@
+export { HudBar, GameOverlay } from "./HUD";

--- a/src/app/playgrounds/chicken-crossing/_lib/game.test.ts
+++ b/src/app/playgrounds/chicken-crossing/_lib/game.test.ts
@@ -1,0 +1,210 @@
+import {
+  COLS,
+  ROWS,
+  GOAL_ROW,
+  START_ROW,
+  createLevel,
+  respawn,
+  advanceBikes,
+  tickTimer,
+  hop,
+  checkCollision,
+  atGoal,
+  buildLanes,
+  safeStripCount,
+  baseSpeed,
+  bikesPerLane,
+  timeBonus,
+  type GameState,
+  type Bike,
+} from "./game";
+
+// Deterministic rng for reproducible level generation.
+const fixedRng = () => 0.5;
+
+describe("createLevel", () => {
+  it("places the chicken on the start row, centred", () => {
+    const s = createLevel(1, fixedRng);
+    expect(s.chicken.row).toBe(START_ROW);
+    expect(s.chicken.col).toBe(Math.floor(COLS / 2));
+    expect(s.bestRow).toBe(START_ROW);
+  });
+
+  it("gives one lane per row with grass at goal and start", () => {
+    const s = createLevel(1, fixedRng);
+    expect(s.lanes).toHaveLength(ROWS);
+    expect(s.lanes[GOAL_ROW].type).toBe("grass");
+    expect(s.lanes[START_ROW].type).toBe("grass");
+  });
+
+  it("only spawns bikes on road lanes", () => {
+    const s = createLevel(3, fixedRng);
+    const roadRows = new Set(
+      s.lanes.filter((l) => l.type === "road").map((l) => l.row),
+    );
+    for (const bike of s.bikes) {
+      expect(roadRows.has(bike.row)).toBe(true);
+    }
+  });
+
+  it("sets a per-level countdown", () => {
+    const s = createLevel(1, fixedRng);
+    expect(s.timeLeft).toBe(s.levelDuration);
+    expect(s.levelDuration).toBeGreaterThan(0);
+  });
+});
+
+describe("level progression", () => {
+  it("fewer safe strips as levels climb", () => {
+    expect(safeStripCount(1)).toBeGreaterThanOrEqual(safeStripCount(5));
+    expect(safeStripCount(10)).toBe(0);
+  });
+
+  it("faster bikes at higher levels", () => {
+    expect(baseSpeed(5)).toBeGreaterThan(baseSpeed(1));
+  });
+
+  it("more bikes per lane at higher levels, capped", () => {
+    expect(bikesPerLane(1)).toBeLessThanOrEqual(bikesPerLane(9));
+    expect(bikesPerLane(99)).toBeLessThanOrEqual(4);
+  });
+
+  it("adjacent road lanes travel in opposite directions", () => {
+    const lanes = buildLanes(1).filter((l) => l.type === "road");
+    for (let i = 1; i < lanes.length; i++) {
+      if (lanes[i].row === lanes[i - 1].row + 1) {
+        expect(lanes[i].dir).not.toBe(lanes[i - 1].dir);
+      }
+    }
+  });
+});
+
+describe("hop", () => {
+  it("moves up and awards a row of progress", () => {
+    const s = createLevel(1, fixedRng);
+    const gained = hop(s, "up");
+    expect(s.chicken.row).toBe(START_ROW - 1);
+    expect(gained).toBe(1);
+    expect(s.bestRow).toBe(START_ROW - 1);
+  });
+
+  it("does not award points for retreading old ground", () => {
+    const s = createLevel(1, fixedRng);
+    hop(s, "up");
+    expect(hop(s, "down")).toBe(0); // back down: no progress
+    expect(hop(s, "up")).toBe(0); // returning to a row already reached: no progress
+  });
+
+  it("clamps at the grid edges", () => {
+    const s = createLevel(1, fixedRng);
+    s.chicken = { col: 0, row: GOAL_ROW };
+    hop(s, "up");
+    expect(s.chicken.row).toBe(GOAL_ROW);
+    hop(s, "left");
+    expect(s.chicken.col).toBe(0);
+    s.chicken = { col: COLS - 1, row: START_ROW };
+    hop(s, "down");
+    expect(s.chicken.row).toBe(START_ROW);
+    hop(s, "right");
+    expect(s.chicken.col).toBe(COLS - 1);
+  });
+});
+
+describe("advanceBikes", () => {
+  const makeState = (bike: Bike): GameState => ({
+    level: 1,
+    lanes: [],
+    bikes: [bike],
+    chicken: { col: 0, row: 5 },
+    timeLeft: 10,
+    levelDuration: 10,
+    bestRow: START_ROW,
+  });
+
+  it("moves a rightward bike forward", () => {
+    const s = makeState({ row: 5, x: 2, speed: 3, dir: 1, length: 1 });
+    advanceBikes(s, 1);
+    expect(s.bikes[0].x).toBeCloseTo(5);
+  });
+
+  it("wraps a rightward bike back near the left edge", () => {
+    const s = makeState({ row: 5, x: COLS - 0.5, speed: 2, dir: 1, length: 1 });
+    advanceBikes(s, 1);
+    // 12.5 -> 14.5, wraps by (COLS + length) to reappear from the left.
+    expect(s.bikes[0].x).toBeLessThan(1);
+    expect(s.bikes[0].x).toBeGreaterThanOrEqual(-1);
+  });
+
+  it("wraps a leftward bike back near the right edge", () => {
+    const s = makeState({ row: 5, x: -0.5, speed: 2, dir: -1, length: 1 });
+    advanceBikes(s, 1);
+    // -0.5 -> -2.5, wraps by (COLS + length) to reappear from the right.
+    expect(s.bikes[0].x).toBeGreaterThan(COLS - 2);
+    expect(s.bikes[0].x).toBeLessThanOrEqual(COLS);
+  });
+});
+
+describe("checkCollision", () => {
+  const baseState = (chickenCol: number, chickenRow: number, bikes: Bike[]): GameState => ({
+    level: 1,
+    lanes: [],
+    bikes,
+    chicken: { col: chickenCol, row: chickenRow },
+    timeLeft: 10,
+    levelDuration: 10,
+    bestRow: START_ROW,
+  });
+
+  it("detects an overlapping bike in the same row", () => {
+    const s = baseState(5, 3, [{ row: 3, x: 5, speed: 1, dir: 1, length: 1 }]);
+    expect(checkCollision(s)).toBe(true);
+  });
+
+  it("ignores a bike in a different row", () => {
+    const s = baseState(5, 3, [{ row: 4, x: 5, speed: 1, dir: 1, length: 1 }]);
+    expect(checkCollision(s)).toBe(false);
+  });
+
+  it("treats an adjacent-but-not-overlapping bike as a miss", () => {
+    const s = baseState(5, 3, [{ row: 3, x: 6.5, speed: 1, dir: 1, length: 1 }]);
+    expect(checkCollision(s)).toBe(false);
+  });
+});
+
+describe("atGoal", () => {
+  it("is true only on the goal row", () => {
+    const s = createLevel(1, fixedRng);
+    expect(atGoal(s)).toBe(false);
+    s.chicken.row = GOAL_ROW;
+    expect(atGoal(s)).toBe(true);
+  });
+});
+
+describe("respawn", () => {
+  it("returns the chicken to the start and resets progress", () => {
+    const s = createLevel(1, fixedRng);
+    hop(s, "up");
+    hop(s, "up");
+    respawn(s);
+    expect(s.chicken.row).toBe(START_ROW);
+    expect(s.bestRow).toBe(START_ROW);
+  });
+});
+
+describe("tickTimer", () => {
+  it("counts down and floors at zero", () => {
+    const s = createLevel(1, fixedRng);
+    s.timeLeft = 1;
+    tickTimer(s, 0.4);
+    expect(s.timeLeft).toBeCloseTo(0.6);
+    tickTimer(s, 5);
+    expect(s.timeLeft).toBe(0);
+  });
+});
+
+describe("timeBonus", () => {
+  it("awards points per whole second remaining", () => {
+    expect(timeBonus(0)).toBe(0);
+    expect(timeBonus(3.9)).toBe(3 * 5);
+  });
+});

--- a/src/app/playgrounds/chicken-crossing/_lib/game.ts
+++ b/src/app/playgrounds/chicken-crossing/_lib/game.ts
@@ -1,0 +1,212 @@
+// Pure, DOM-free game logic for "Fowl Play" — a chicken crossing the road,
+// dodging bikes. Grid model: the chicken hops cell-to-cell; bikes slide
+// continuously along a lane and wrap around. All positions are in *cell units*
+// so rendering can pick whatever pixel size fits the container.
+
+export const COLS = 13;
+export const ROWS = 15;
+
+// Row 0 is the goal (top), row ROWS-1 is the start (bottom). Everything between
+// is either a road lane or a grass "safe strip".
+export const GOAL_ROW = 0;
+export const START_ROW = ROWS - 1;
+
+export type Direction = "up" | "down" | "left" | "right";
+export type RowType = "grass" | "road";
+
+export interface Lane {
+  row: number;
+  type: RowType;
+  // Travel direction for road rows: +1 = rightward, -1 = leftward. 0 for grass.
+  dir: -1 | 0 | 1;
+}
+
+export interface Bike {
+  row: number;
+  x: number; // left edge, in cell units, may sit off-grid mid-wrap
+  speed: number; // cells/sec, always positive (direction comes from the lane)
+  dir: -1 | 1;
+  length: number; // in cells
+}
+
+export interface Chicken {
+  col: number;
+  row: number;
+}
+
+export interface GameState {
+  level: number;
+  lanes: Lane[];
+  bikes: Bike[];
+  chicken: Chicken;
+  timeLeft: number; // seconds remaining in the crossing
+  levelDuration: number;
+  // Lowest row index the chicken has reached this crossing (row 0 = top/goal),
+  // used to award points only for fresh forward progress.
+  bestRow: number;
+}
+
+export type Rng = () => number;
+
+// --- Scoring ---------------------------------------------------------------
+
+export const POINTS_PER_ROW = 10;
+export const LEVEL_CLEAR_BONUS = 100;
+// Each whole second left on the clock when the goal is reached.
+export const TIME_BONUS_PER_SEC = 5;
+
+export function timeBonus(timeLeft: number): number {
+  return Math.max(0, Math.floor(timeLeft)) * TIME_BONUS_PER_SEC;
+}
+
+// --- Level shaping ---------------------------------------------------------
+
+// Number of grass safe strips sitting between goal and start. Starts generous
+// and dries up as levels climb, so the road becomes one long gauntlet.
+export function safeStripCount(level: number): number {
+  return Math.max(0, 2 - Math.floor((level - 1) / 2));
+}
+
+// Base bike speed (cells/sec) ramps with level.
+export function baseSpeed(level: number): number {
+  return 2 + (level - 1) * 0.6;
+}
+
+// Bikes per lane grows slowly with level; more bikes = less daylight.
+export function bikesPerLane(level: number): number {
+  return Math.min(2 + Math.floor((level - 1) / 2), 4);
+}
+
+export function levelDurationFor(level: number): number {
+  // Tighter clock as things speed up, but never punishing.
+  return Math.max(20, 45 - (level - 1) * 2);
+}
+
+// Build the lane layout for a level. The middle rows (between goal and start)
+// are road by default, with `safeStripCount` of them converted to grass,
+// spaced roughly evenly so the player gets breathers.
+export function buildLanes(level: number): Lane[] {
+  const lanes: Lane[] = [];
+  const middleRows: number[] = [];
+  for (let row = 0; row < ROWS; row++) {
+    if (row === GOAL_ROW || row === START_ROW) {
+      lanes.push({ row, type: "grass", dir: 0 });
+    } else {
+      middleRows.push(row);
+      lanes.push({ row, type: "road", dir: row % 2 === 0 ? 1 : -1 });
+    }
+  }
+
+  const strips = Math.min(safeStripCount(level), middleRows.length);
+  for (let i = 0; i < strips; i++) {
+    // Evenly distribute safe strips across the middle band.
+    const idx = Math.round(((i + 1) * middleRows.length) / (strips + 1)) - 1;
+    const row = middleRows[Math.max(0, Math.min(middleRows.length - 1, idx))];
+    lanes[row] = { row, type: "grass", dir: 0 };
+  }
+
+  return lanes;
+}
+
+// Populate a lane with evenly spaced bikes, jittered so lanes don't march in
+// lockstep. All bikes in a lane share one speed (so they never bunch up), but
+// that speed varies from lane to lane for texture.
+function spawnBikes(lane: Lane, level: number, rng: Rng): Bike[] {
+  if (lane.type !== "road") return [];
+  const count = bikesPerLane(level);
+  const gap = COLS / count;
+  const speed = baseSpeed(level) * (0.7 + rng() * 0.9); // 0.7x–1.6x of base, per lane
+  const length = 1;
+  const jitter = rng() * gap;
+  const bikes: Bike[] = [];
+  for (let i = 0; i < count; i++) {
+    const x = (i * gap + jitter) % COLS;
+    bikes.push({ row: lane.row, x, speed, dir: lane.dir === -1 ? -1 : 1, length });
+  }
+  return bikes;
+}
+
+export function createLevel(level: number, rng: Rng = Math.random): GameState {
+  const lanes = buildLanes(level);
+  const bikes = lanes.flatMap((lane) => spawnBikes(lane, level, rng));
+  const levelDuration = levelDurationFor(level);
+  return {
+    level,
+    lanes,
+    bikes,
+    chicken: { col: Math.floor(COLS / 2), row: START_ROW },
+    timeLeft: levelDuration,
+    levelDuration,
+    bestRow: START_ROW,
+  };
+}
+
+// Reset the chicken to the start row after a crash, keeping the same level.
+export function respawn(state: GameState): void {
+  state.chicken = { col: Math.floor(COLS / 2), row: START_ROW };
+  state.bestRow = START_ROW;
+}
+
+// --- Per-frame simulation (mutating for performance) -----------------------
+
+// Advance every bike by dt seconds and wrap it around the play field.
+export function advanceBikes(state: GameState, dt: number): void {
+  for (const bike of state.bikes) {
+    bike.x += bike.dir * bike.speed * dt;
+    if (bike.dir > 0 && bike.x >= COLS) {
+      bike.x -= COLS + bike.length;
+    } else if (bike.dir < 0 && bike.x + bike.length <= 0) {
+      bike.x += COLS + bike.length;
+    }
+  }
+}
+
+export function tickTimer(state: GameState, dt: number): void {
+  state.timeLeft = Math.max(0, state.timeLeft - dt);
+}
+
+// Move the chicken one cell, clamped to the grid. Returns the number of rows
+// of *fresh* forward progress made (0 or 1) so the caller can award points.
+export function hop(state: GameState, dir: Direction): number {
+  const { chicken } = state;
+  switch (dir) {
+    case "up":
+      chicken.row = Math.max(GOAL_ROW, chicken.row - 1);
+      break;
+    case "down":
+      chicken.row = Math.min(START_ROW, chicken.row + 1);
+      break;
+    case "left":
+      chicken.col = Math.max(0, chicken.col - 1);
+      break;
+    case "right":
+      chicken.col = Math.min(COLS - 1, chicken.col + 1);
+      break;
+  }
+  if (chicken.row < state.bestRow) {
+    const gained = state.bestRow - chicken.row;
+    state.bestRow = chicken.row;
+    return gained;
+  }
+  return 0;
+}
+
+// Forgiving hitbox: shave the edges so a near-miss reads as a miss.
+const HIT_INSET = 0.2;
+
+export function checkCollision(state: GameState): boolean {
+  const { chicken, bikes } = state;
+  const cLeft = chicken.col + HIT_INSET;
+  const cRight = chicken.col + 1 - HIT_INSET;
+  for (const bike of bikes) {
+    if (bike.row !== chicken.row) continue;
+    const bLeft = bike.x + HIT_INSET;
+    const bRight = bike.x + bike.length - HIT_INSET;
+    if (cLeft < bRight && cRight > bLeft) return true;
+  }
+  return false;
+}
+
+export function atGoal(state: GameState): boolean {
+  return state.chicken.row === GOAL_ROW;
+}

--- a/src/app/playgrounds/chicken-crossing/_lib/sprites.ts
+++ b/src/app/playgrounds/chicken-crossing/_lib/sprites.ts
@@ -1,0 +1,215 @@
+// Retro pixel-art drawing helpers. Everything is drawn into a low internal
+// resolution canvas that GameCanvas upscales with image smoothing OFF, so the
+// chunky-pixel look is uniform across the crafted chicken sprite and the
+// procedurally drawn bikes.
+
+// --- Scene palette ---------------------------------------------------------
+
+export const COLORS = {
+  grass: "#3a7d34",
+  grassAlt: "#347030",
+  road: "#3a3a44",
+  roadAlt: "#33333c",
+  laneMark: "#e7d84b",
+  goalGlow: "#7bd66b",
+  shadow: "rgba(0,0,0,0.28)",
+};
+
+// --- Chicken sprite (pixel map) -------------------------------------------
+
+const CHICK = {
+  ".": null,
+  R: "#e23b3b", // comb
+  Y: "#f5a623", // beak / feet
+  W: "#fdfdfd", // body
+  w: "#d9dde3", // body shade
+  K: "#1e1e24", // eye
+} as const;
+
+// Front-facing chicken, 11 wide x 12 tall.
+const CHICKEN_MAP = [
+  "....RRR....",
+  "...RRRRR...",
+  "....YYY....",
+  "...WWWWW...",
+  "..WWWWWWW..",
+  "..WKWWWKW..",
+  "..WWWWWWW..",
+  ".WWWWWWWWW.",
+  ".WWwwwwwWW.",
+  "..WWWWWWW..",
+  "...W...W...",
+  "..YY...YY..",
+];
+
+function drawPixelMap(
+  ctx: CanvasRenderingContext2D,
+  map: string[],
+  palette: Record<string, string | null>,
+  cx: number,
+  cy: number,
+  size: number,
+  squashY = 1,
+): void {
+  const cols = map[0].length;
+  const rows = map.length;
+  const px = size / Math.max(cols, rows);
+  const w = cols * px;
+  const h = rows * px * squashY;
+  const x0 = cx - w / 2;
+  const y0 = cy - h / 2;
+  for (let r = 0; r < rows; r++) {
+    const line = map[r];
+    for (let c = 0; c < cols; c++) {
+      const color = palette[line[c]];
+      if (!color) continue;
+      ctx.fillStyle = color;
+      // +1 on size closes hairline seams between pixels after upscaling.
+      ctx.fillRect(
+        Math.floor(x0 + c * px),
+        Math.floor(y0 + r * px * squashY),
+        Math.ceil(px) + 1,
+        Math.ceil(px * squashY) + 1,
+      );
+    }
+  }
+}
+
+// hopProgress: 0 = settled, 1 = just hopped. Drives a brief squash-and-stretch.
+export function drawChicken(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  cell: number,
+  hopProgress = 0,
+): void {
+  const size = cell * 0.92;
+  // Soft ground shadow.
+  ctx.fillStyle = COLORS.shadow;
+  ctx.beginPath();
+  ctx.ellipse(cx, cy + size * 0.42, size * 0.34, size * 0.12, 0, 0, Math.PI * 2);
+  ctx.fill();
+  const squash = 1 + Math.sin(hopProgress * Math.PI) * 0.12;
+  drawPixelMap(ctx, CHICKEN_MAP, CHICK, cx, cy - hopProgress * cell * 0.18, size, squash);
+}
+
+// --- Bikes (procedural, drawn chunky) --------------------------------------
+
+export interface BikeVariant {
+  frame: string;
+  rider: string;
+  helmet: string;
+}
+
+export const BIKE_VARIANTS: BikeVariant[] = [
+  { frame: "#ff5964", rider: "#2d2d3a", helmet: "#ffd23f" },
+  { frame: "#3fb0ff", rider: "#f4f4f6", helmet: "#ff5964" },
+  { frame: "#8b5cf6", rider: "#111318", helmet: "#3fb0ff" },
+  { frame: "#22c55e", rider: "#111318", helmet: "#ffffff" },
+  { frame: "#f97316", rider: "#f4f4f6", helmet: "#111318" },
+];
+
+const TYRE = "#111318";
+const SKIN = "#f0c090";
+const SPOKE = "#9aa0ac";
+
+function pixelCircle(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  r: number,
+  color: string,
+): void {
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+// Draws a cyclist filling roughly `cell` wide, centred at (cx, cy).
+// faceRight flips the rider's lean to match travel direction.
+export function drawBike(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  cell: number,
+  variantIndex: number,
+  faceRight: boolean,
+): void {
+  const v = BIKE_VARIANTS[variantIndex % BIKE_VARIANTS.length];
+  const s = cell / 16; // sprite unit
+  const dir = faceRight ? 1 : -1;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.scale(dir, 1);
+
+  // Ground shadow.
+  ctx.fillStyle = COLORS.shadow;
+  ctx.beginPath();
+  ctx.ellipse(0, 7 * s, 8 * s, 1.8 * s, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  const wheelR = 3.4 * s;
+  const backX = -5 * s;
+  const frontX = 5 * s;
+  const wheelY = 4 * s;
+
+  // Wheels: black tyre, grey hub, dark centre.
+  for (const wx of [backX, frontX]) {
+    pixelCircle(ctx, wx, wheelY, wheelR, TYRE);
+    pixelCircle(ctx, wx, wheelY, wheelR * 0.55, SPOKE);
+    pixelCircle(ctx, wx, wheelY, wheelR * 0.22, TYRE);
+  }
+
+  // Frame: chunky strokes in the variant colour.
+  ctx.strokeStyle = v.frame;
+  ctx.lineWidth = 1.8 * s;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(backX, wheelY); // rear hub
+  ctx.lineTo(0, wheelY); // bottom bracket
+  ctx.lineTo(-0.5 * s, -1 * s); // seat post
+  ctx.lineTo(backX, wheelY); // seat stay
+  ctx.moveTo(0, wheelY);
+  ctx.lineTo(3.5 * s, -1.5 * s); // down/head tube
+  ctx.lineTo(frontX, wheelY); // fork
+  ctx.moveTo(3.5 * s, -1.5 * s);
+  ctx.lineTo(5.5 * s, -2.5 * s); // handlebar
+  ctx.stroke();
+
+  // Rider: legs, torso, head.
+  ctx.strokeStyle = SKIN;
+  ctx.lineWidth = 1.6 * s;
+  ctx.beginPath();
+  ctx.moveTo(-0.5 * s, -1 * s); // hip
+  ctx.lineTo(1 * s, wheelY); // leg to pedal
+  ctx.stroke();
+
+  ctx.fillStyle = v.rider;
+  ctx.beginPath();
+  ctx.moveTo(-1.5 * s, -1 * s);
+  ctx.lineTo(1.5 * s, -1 * s);
+  ctx.lineTo(4 * s, -6 * s); // lean toward bars
+  ctx.lineTo(2 * s, -6.5 * s);
+  ctx.closePath();
+  ctx.fill();
+
+  // Arm to handlebar.
+  ctx.strokeStyle = SKIN;
+  ctx.lineWidth = 1.4 * s;
+  ctx.beginPath();
+  ctx.moveTo(3 * s, -6 * s);
+  ctx.lineTo(5.5 * s, -2.5 * s);
+  ctx.stroke();
+
+  // Head + helmet.
+  pixelCircle(ctx, 3.4 * s, -7.6 * s, 1.8 * s, SKIN);
+  ctx.fillStyle = v.helmet;
+  ctx.beginPath();
+  ctx.arc(3.4 * s, -7.8 * s, 2 * s, Math.PI, Math.PI * 2);
+  ctx.fill();
+  ctx.fillRect(3.4 * s, -8 * s, 2.4 * s, 1 * s); // visor
+
+  ctx.restore();
+}

--- a/src/app/playgrounds/chicken-crossing/_lib/useBestScore.ts
+++ b/src/app/playgrounds/chicken-crossing/_lib/useBestScore.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+// Persisted high score for Fowl Play. Mirrors the same-tab-notify pattern used
+// by the memory playground: the native `storage` event only fires in *other*
+// tabs, so we keep our own listener set and emit on write.
+
+const KEY = "fowl-play-best";
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+function getSnapshot(): number {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function useBestScore() {
+  const best = useSyncExternalStore(subscribe, getSnapshot, () => 0);
+
+  // Store `score` only when it beats the record. Returns true on a new best.
+  const saveIfBest = useCallback((score: number): boolean => {
+    if (score <= getSnapshot()) return false;
+    try {
+      window.localStorage.setItem(KEY, String(score));
+    } catch {
+      // Storage unavailable (private mode etc.); keep playing regardless.
+    }
+    listeners.forEach((l) => l());
+    return true;
+  }, []);
+
+  return { best, saveIfBest };
+}

--- a/src/app/playgrounds/chicken-crossing/opengraph-image.tsx
+++ b/src/app/playgrounds/chicken-crossing/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Fowl Play";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Fowl Play",
+  "Guide the chicken across the road, dodge the bikes and beat the clock.",
+);

--- a/src/app/playgrounds/chicken-crossing/page.tsx
+++ b/src/app/playgrounds/chicken-crossing/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { ChickenCrossing } from "./_components/ChickenCrossing";
+
+const description =
+  "Guide the chicken across the road, dodge the bikes and beat the clock. Each level gets faster.";
+
+export const metadata: Metadata = {
+  title: "Fowl Play | Playground",
+  description,
+  openGraph: {
+    title: "Fowl Play",
+    description,
+  },
+};
+
+export default function ChickenCrossingPage() {
+  return <ChickenCrossing />;
+}


### PR DESCRIPTION
### What

Adds a new playground at `/playgrounds/chicken-crossing`: a Frogger-style arcade game where a chicken crosses the road while dodging bikes.

- One crossing per level; reach the top to clear the level, and each new level adds bikes, speeds them up and thins out the grass safe strips.
- 3 lives, a per-level countdown, and scoring (per row of progress + level-clear bonus + time bonus). High score persisted to `localStorage`.
- Retro pixel art: the board renders at a fixed low internal resolution and is upscaled with pixelated rendering, with a CRT scanline veil. Chicken is a pixel-map sprite; bikes are drawn procedurally in several colour variants.
- Controls: arrow keys / WASD on desktop, swipe to steer and tap to hop on touch.
- Homepage card with an auto-playing preview loop, plus OpenGraph image.

### Structure

Follows the existing real-time-canvas playground pattern (boids / three-body): pure, DOM-free game logic in `_lib/game.ts` (fully unit tested), the `requestAnimationFrame` loop in `GameCanvas` reading a mutable sim ref, and React state reserved for meta/HUD. No XState (wrong fit for a per-frame loop).

### Risk / testing

- `pnpm test` green (21 new unit tests covering bike movement/wrap, collision, hop clamping, goal detection, level progression and scoring).
- `pnpm build` and typecheck pass; the new route prerenders.
- Lint introduces no new problems (the remaining errors on `connect-four`, `food-analyzer` and `lights-out` pre-date this branch).
- The interactive canvas/game loop is client-side, so it was smoke-tested via SSR (page serves 200) rather than driven end-to-end in a browser. Worth a quick manual playtest of the controls and level ramp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)