### PR TITLE
feat: add "Echo" Simon memory game playground

### DIFF
--- a/src/app/_components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/app/_components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,7 +9,11 @@ export function Breadcrumbs() {
   const pathArray = pathname.split("/").filter((path) => path);
 
   return (
-    <nav aria-label="breadcrumb">
+    <nav
+      aria-label="breadcrumb"
+      className="select-none"
+      style={{ WebkitTouchCallout: "none", WebkitTapHighlightColor: "transparent" }}
+    >
       <ol>
         <li className="inline-block">
           {pathArray.length === 0 ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,8 +20,17 @@ import { BoidsPreview } from "./playgrounds/boids/Preview";
 import { ThreeBodyPreview } from "./playgrounds/three-body/Preview";
 import { LotteryPreview } from "./playgrounds/lottery/Preview";
 import { MemoryPreview } from "./playgrounds/memory/Preview";
+import { SimonPreview } from "./playgrounds/simon/Preview";
 
 const playgrounds = [
+  {
+    id: "simon",
+    title: "Echo",
+    description:
+      "A Simon memory game. Watch the pattern of colours and tones, then tap it back. It grows every round.",
+    href: "/playgrounds/simon",
+    preview: SimonPreview,
+  },
   {
     id: "spirograph",
     title: "Spirograph",

--- a/src/app/playgrounds/simon/Preview.tsx
+++ b/src/app/playgrounds/simon/Preview.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useIntersectionObserver } from "../../_hooks";
+import { Disc } from "./_components/Disc";
+
+const DEMO_SEQUENCE = [0, 1, 3, 2, 1, 0, 2, 3];
+const LIT_MS = 360;
+const STEP_MS = 560;
+
+export function SimonPreview() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver(containerRef);
+  const [lit, setLit] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const timers: number[] = [];
+    let i = 0;
+
+    const tick = () => {
+      setLit(DEMO_SEQUENCE[i % DEMO_SEQUENCE.length]);
+      timers.push(window.setTimeout(() => setLit(null), LIT_MS));
+      timers.push(
+        window.setTimeout(() => {
+          i += 1;
+          tick();
+        }, STEP_MS),
+      );
+    };
+    tick();
+
+    return () => {
+      timers.forEach((id) => clearTimeout(id));
+      setLit(null);
+    };
+  }, [isVisible]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-full w-full items-center justify-center bg-[#0b0b12] p-6"
+    >
+      <Disc lit={lit} onPad={() => {}} disabled />
+    </div>
+  );
+}

--- a/src/app/playgrounds/simon/_components/Disc/Disc.tsx
+++ b/src/app/playgrounds/simon/_components/Disc/Disc.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+// The classic Simon disc: a donut split into four coloured quadrants that light
+// up. SVG paths give crisp, scalable, huge touch targets. Pointer events cover
+// mouse and touch in one path.
+
+const CX = 100;
+const CY = 100;
+const OUTER = 95;
+const INNER = 36;
+const GAP = 2.5; // degrees of gap between quadrants
+
+// Annular sector path from startDeg to endDeg (SVG angles: 0 = east, clockwise).
+function sector(startDeg: number, endDeg: number): string {
+  const s = (startDeg * Math.PI) / 180;
+  const e = (endDeg * Math.PI) / 180;
+  const pt = (r: number, a: number) => [CX + r * Math.cos(a), CY + r * Math.sin(a)];
+  const [x1, y1] = pt(OUTER, s);
+  const [x2, y2] = pt(OUTER, e);
+  const [x3, y3] = pt(INNER, e);
+  const [x4, y4] = pt(INNER, s);
+  const large = endDeg - startDeg > 180 ? 1 : 0;
+  return [
+    `M ${x1} ${y1}`,
+    `A ${OUTER} ${OUTER} 0 ${large} 1 ${x2} ${y2}`,
+    `L ${x3} ${y3}`,
+    `A ${INNER} ${INNER} 0 ${large} 0 ${x4} ${y4}`,
+    "Z",
+  ].join(" ");
+}
+
+interface PadDef {
+  base: string;
+  lit: string;
+  start: number;
+  end: number;
+}
+
+// Classic layout: green top-left, red top-right, yellow bottom-left, blue
+// bottom-right. Angles run clockwise from east with y pointing down.
+const PADS: PadDef[] = [
+  { base: "#15803d", lit: "#4ade80", start: 180, end: 270 }, // 0 green (top-left)
+  { base: "#b91c1c", lit: "#f87171", start: 270, end: 360 }, // 1 red (top-right)
+  { base: "#a16207", lit: "#fde047", start: 90, end: 180 }, //  2 yellow (bottom-left)
+  { base: "#1d4ed8", lit: "#60a5fa", start: 0, end: 90 }, //    3 blue (bottom-right)
+];
+
+interface DiscProps {
+  lit: number | null;
+  onPad: (pad: number) => void;
+  onRelease?: (pad: number) => void;
+  disabled?: boolean;
+  hub?: React.ReactNode;
+}
+
+export function Disc({ lit, onPad, onRelease, disabled = false, hub }: DiscProps) {
+  return (
+    <div
+      className="relative aspect-square w-full max-w-[min(80vw,26rem)] select-none"
+      style={{
+        touchAction: "none",
+        WebkitUserSelect: "none",
+        userSelect: "none",
+        WebkitTouchCallout: "none",
+        WebkitTapHighlightColor: "transparent",
+      }}
+    >
+      <svg
+        viewBox="0 0 200 200"
+        className="h-full w-full drop-shadow-2xl"
+        style={{ touchAction: "none", WebkitTapHighlightColor: "transparent" }}
+      >
+        {PADS.map((pad, i) => {
+          const isLit = lit === i;
+          return (
+            <path
+              key={i}
+              d={sector(pad.start + GAP, pad.end - GAP)}
+              fill={isLit ? pad.lit : pad.base}
+              stroke="#0b0b12"
+              strokeWidth={2}
+              onPointerDown={(e) => {
+                if (disabled) return;
+                e.preventDefault();
+                // Capture so we reliably get pointerup on this pad (esp. touch).
+                e.currentTarget.setPointerCapture?.(e.pointerId);
+                onPad(i);
+              }}
+              onPointerUp={() => onRelease?.(i)}
+              onPointerCancel={() => onRelease?.(i)}
+              onPointerLeave={() => onRelease?.(i)}
+              style={{
+                cursor: disabled ? "default" : "pointer",
+                pointerEvents: disabled ? "none" : "auto",
+                filter: isLit ? "brightness(1.15)" : "brightness(0.92)",
+                transition: "fill 90ms linear, filter 90ms linear",
+              }}
+              aria-label={["green", "red", "yellow", "blue"][i]}
+            />
+          );
+        })}
+        {/* Hub ring */}
+        <circle cx={CX} cy={CY} r={INNER - 2} fill="#0b0b12" stroke="#2a2a38" strokeWidth={2} />
+      </svg>
+
+      {/* Hub content overlay (crisp HTML text). */}
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <div className="flex flex-col items-center justify-center text-center">{hub}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/simon/_components/Disc/index.tsx
+++ b/src/app/playgrounds/simon/_components/Disc/index.tsx
@@ -1,0 +1,1 @@
+export { Disc } from "./Disc";

--- a/src/app/playgrounds/simon/_components/Simon/Simon.tsx
+++ b/src/app/playgrounds/simon/_components/Simon/Simon.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Disc } from "../Disc";
+import { extend, isInputCorrect, type Pad } from "../../_lib/game";
+import {
+  playPad,
+  playError,
+  resumeAudio,
+  setMuted,
+  startPad,
+  stopPad,
+  stopAllPads,
+} from "../../_lib/sound";
+import { useBestScore } from "../../_lib/useBestScore";
+
+type Phase = "idle" | "playback" | "input" | "wrong" | "gameOver";
+
+const START_LIVES = 3;
+const LIT_MS = 420; // how long each pad glows during playback
+const GAP_MS = 200; // silence between playback flashes
+const FIRST_DELAY = 450; // pause before a sequence starts playing
+const ROUND_PAUSE = 650; // pause after a round is cleared, before the next
+const WRONG_PAUSE = 950; // pause after a mistake, before the replay
+
+export function Simon() {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [sequence, setSequence] = useState<Pad[]>([]);
+  const [lives, setLives] = useState(START_LIVES);
+  const [lit, setLit] = useState<number | null>(null);
+  const [muted, setMutedState] = useState(false);
+  const [isNewBest, setIsNewBest] = useState(false);
+
+  const { best, saveIfBest } = useBestScore();
+
+  const timers = useRef<number[]>([]);
+  const inputIndex = useRef(0);
+  const livesRef = useRef(START_LIVES);
+  const phaseRef = useRef<Phase>("idle");
+  const seqRef = useRef<Pad[]>([]);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+  useEffect(() => {
+    seqRef.current = sequence;
+  }, [sequence]);
+
+  const clearTimers = useCallback(() => {
+    timers.current.forEach((id) => clearTimeout(id));
+    timers.current = [];
+  }, []);
+
+  const schedule = useCallback((fn: () => void, delay: number) => {
+    const id = window.setTimeout(fn, delay);
+    timers.current.push(id);
+  }, []);
+
+  // Clear any pending timers and silence held tones on unmount.
+  useEffect(
+    () => () => {
+      clearTimers();
+      stopAllPads();
+    },
+    [clearTimers],
+  );
+
+  // Flash the whole sequence, then hand control to the player.
+  const playback = useCallback(
+    (seq: Pad[]) => {
+      clearTimers();
+      setPhase("playback");
+      setLit(null);
+      inputIndex.current = 0;
+      let t = FIRST_DELAY;
+      for (const pad of seq) {
+        schedule(() => {
+          setLit(pad);
+          playPad(pad, LIT_MS / 1000);
+        }, t);
+        schedule(() => setLit(null), t + LIT_MS);
+        t += LIT_MS + GAP_MS;
+      }
+      schedule(() => setPhase("input"), t);
+    },
+    [clearTimers, schedule],
+  );
+
+  const startGame = useCallback(() => {
+    resumeAudio();
+    livesRef.current = START_LIVES;
+    setLives(START_LIVES);
+    setIsNewBest(false);
+    const seq = extend([]);
+    setSequence(seq);
+    playback(seq);
+  }, [playback]);
+
+  const handleWrong = useCallback(() => {
+    playError();
+    const remaining = livesRef.current - 1;
+    livesRef.current = remaining;
+    setLives(remaining);
+    if (remaining <= 0) {
+      clearTimers();
+      setPhase("gameOver");
+      // Completed rounds = sequence length minus the one they just failed.
+      setIsNewBest(saveIfBest(Math.max(0, seqRef.current.length - 1)));
+    } else {
+      setPhase("wrong");
+      schedule(() => playback(seqRef.current), WRONG_PAUSE);
+    }
+  }, [clearTimers, schedule, playback, saveIfBest]);
+
+  const handlePress = useCallback(
+    (pad: number) => {
+      if (phaseRef.current !== "input") return;
+      resumeAudio();
+      setLit(pad);
+      startPad(pad); // rings until the pad is released
+
+      const idx = inputIndex.current;
+      if (!isInputCorrect(seqRef.current, idx, pad as Pad)) {
+        handleWrong();
+        return;
+      }
+      inputIndex.current = idx + 1;
+      if (inputIndex.current >= seqRef.current.length) {
+        // Round cleared: block input, grow the sequence, replay.
+        setPhase("playback");
+        const nextSeq = extend(seqRef.current);
+        setSequence(nextSeq);
+        schedule(() => playback(nextSeq), ROUND_PAUSE);
+      }
+    },
+    [schedule, playback, handleWrong],
+  );
+
+  const handleRelease = useCallback((pad: number) => {
+    stopPad(pad);
+    setLit((cur) => (cur === pad ? null : cur));
+  }, []);
+
+  const toggleMute = useCallback(() => {
+    setMutedState((m) => {
+      const next = !m;
+      setMuted(next);
+      return next;
+    });
+  }, []);
+
+  const round = sequence.length;
+  const playing = phase !== "idle" && phase !== "gameOver";
+
+  const hubLabel: Record<Phase, string> = {
+    idle: "",
+    playback: "Watch",
+    input: "Your turn",
+    wrong: "Oops",
+    gameOver: "",
+  };
+
+  return (
+    <div
+      className="flex h-full flex-col items-center select-none bg-[#0b0b12] text-white"
+      style={{ WebkitTouchCallout: "none", WebkitTapHighlightColor: "transparent" }}
+    >
+      {/* Status bar */}
+      <div className="flex w-full max-w-md items-center justify-between gap-4 px-4 py-3">
+        <div className="flex items-center gap-5">
+          <Stat label="Round" value={playing || phase === "gameOver" ? round : 0} />
+          <Stat label="Best" value={best} />
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
+            {Array.from({ length: START_LIVES }, (_, i) => (
+              <span
+                key={i}
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ background: i < lives ? "#f87171" : "rgba(255,255,255,0.15)" }}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={toggleMute}
+            className="font-mono text-[10px] uppercase tracking-widest text-white/50 transition-colors hover:text-white"
+          >
+            {muted ? "Sound off" : "Sound on"}
+          </button>
+        </div>
+      </div>
+
+      {/* Disc + overlays */}
+      <div className="relative flex min-h-0 flex-1 items-center justify-center p-4">
+        <Disc
+          lit={lit}
+          onPad={handlePress}
+          onRelease={handleRelease}
+          disabled={phase !== "input"}
+          hub={
+            playing ? (
+              <>
+                <span className="font-roboto-slab text-3xl font-black leading-none text-white">
+                  {round}
+                </span>
+                <span className="mt-1 font-mono text-[8px] uppercase tracking-widest text-white/50">
+                  {hubLabel[phase]}
+                </span>
+              </>
+            ) : null
+          }
+        />
+
+        {(phase === "idle" || phase === "gameOver") && (
+          <div className="absolute inset-0 flex items-center justify-center p-4 text-center">
+            <div className="flex flex-col items-center rounded-2xl bg-black/55 px-8 py-6 backdrop-blur-sm">
+              {phase === "idle" ? (
+                <>
+                  <h1 className="font-roboto-slab text-4xl font-black text-white sm:text-5xl">
+                    Echo
+                  </h1>
+                  <p className="mt-2 max-w-[16rem] font-mono text-xs leading-relaxed text-white/60">
+                    Watch the pattern, then tap it back. It grows every round.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h2 className="font-roboto-slab text-4xl font-black text-[#f87171]">Game over</h2>
+                  <p className="mt-2 font-mono text-sm text-white/70">
+                    You reached round{" "}
+                    <span className="font-bold text-white">{Math.max(0, round - 1)}</span>
+                  </p>
+                  {isNewBest && (
+                    <p className="mt-1 font-mono text-xs font-bold uppercase tracking-widest text-[#fde047]">
+                      ★ New best ★
+                    </p>
+                  )}
+                </>
+              )}
+              <button
+                type="button"
+                onClick={startGame}
+                className="mt-4 rounded-full border-2 border-white bg-white px-7 py-2 font-mono text-sm font-bold uppercase tracking-widest text-[#0b0b12] transition-transform hover:scale-105 active:scale-95"
+              >
+                {phase === "idle" ? "Start" : "Play again"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col leading-none">
+      <span className="font-mono text-[9px] uppercase tracking-widest text-white/40">{label}</span>
+      <span className="font-mono text-lg font-bold tabular-nums text-white">{value}</span>
+    </div>
+  );
+}

--- a/src/app/playgrounds/simon/_components/Simon/index.tsx
+++ b/src/app/playgrounds/simon/_components/Simon/index.tsx
@@ -1,0 +1,1 @@
+export { Simon } from "./Simon";

--- a/src/app/playgrounds/simon/_lib/game.test.ts
+++ b/src/app/playgrounds/simon/_lib/game.test.ts
@@ -1,0 +1,51 @@
+import { PAD_COUNT, nextStep, extend, isInputCorrect, type Pad } from "./game";
+
+describe("nextStep", () => {
+  it("returns a pad in range", () => {
+    // Sweep the rng across its [0, 1) domain.
+    for (let i = 0; i < 100; i++) {
+      const pad = nextStep(() => i / 100);
+      expect(pad).toBeGreaterThanOrEqual(0);
+      expect(pad).toBeLessThan(PAD_COUNT);
+    }
+  });
+
+  it("maps rng buckets to distinct pads", () => {
+    expect(nextStep(() => 0)).toBe(0);
+    expect(nextStep(() => 0.3)).toBe(1);
+    expect(nextStep(() => 0.6)).toBe(2);
+    expect(nextStep(() => 0.9)).toBe(3);
+  });
+});
+
+describe("extend", () => {
+  it("grows the sequence by exactly one, without mutating the original", () => {
+    const seq: Pad[] = [0, 2];
+    const next = extend(seq, () => 0.9);
+    expect(next).toHaveLength(3);
+    expect(next).toEqual([0, 2, 3]);
+    expect(seq).toEqual([0, 2]); // original untouched
+  });
+
+  it("builds a valid sequence from empty via repeated calls", () => {
+    let seq: Pad[] = [];
+    const rng = () => 0.5; // always pad 2
+    for (let i = 0; i < 5; i++) seq = extend(seq, rng);
+    expect(seq).toEqual([2, 2, 2, 2, 2]);
+  });
+});
+
+describe("isInputCorrect", () => {
+  const seq: Pad[] = [1, 3, 0];
+
+  it("is true when the pad matches the expected step", () => {
+    expect(isInputCorrect(seq, 0, 1)).toBe(true);
+    expect(isInputCorrect(seq, 1, 3)).toBe(true);
+    expect(isInputCorrect(seq, 2, 0)).toBe(true);
+  });
+
+  it("is false on a mismatch", () => {
+    expect(isInputCorrect(seq, 0, 2)).toBe(false);
+    expect(isInputCorrect(seq, 1, 0)).toBe(false);
+  });
+});

--- a/src/app/playgrounds/simon/_lib/game.ts
+++ b/src/app/playgrounds/simon/_lib/game.ts
@@ -1,0 +1,23 @@
+// Pure, DOM-free logic for Echo (a Simon memory game). The interactive flow,
+// timers and audio live in the component; this module just owns the sequence.
+
+export const PAD_COUNT = 4;
+
+export type Pad = 0 | 1 | 2 | 3;
+
+export type Rng = () => number;
+
+// A single random pad index.
+export function nextStep(rng: Rng = Math.random): Pad {
+  return Math.floor(rng() * PAD_COUNT) as Pad;
+}
+
+// Return a new sequence with one extra random step appended (never mutates).
+export function extend(sequence: Pad[], rng: Rng = Math.random): Pad[] {
+  return [...sequence, nextStep(rng)];
+}
+
+// Does `pad` match the expected step at `index` of the sequence?
+export function isInputCorrect(sequence: Pad[], index: number, pad: Pad): boolean {
+  return sequence[index] === pad;
+}

--- a/src/app/playgrounds/simon/_lib/sound.ts
+++ b/src/app/playgrounds/simon/_lib/sound.ts
@@ -1,0 +1,100 @@
+// Web Audio tones for Echo. Each pad has its own pitch (classic Simon tuning:
+// G3 / C4 / E4 / G4) so every colour sounds distinct. The AudioContext is
+// created lazily and resumed on the first user gesture, satisfying mobile
+// autoplay policies. No dependency — a handful of oscillator lines.
+
+const PAD_FREQS = [196.0, 261.63, 329.63, 392.0]; // one unique tone per pad
+
+let ctx: AudioContext | null = null;
+let muted = false;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (!ctx) {
+    const AC =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!AC) return null;
+    ctx = new AC();
+  }
+  return ctx;
+}
+
+// Call from a user gesture (e.g. the Start tap) to unlock/resume audio.
+export function resumeAudio(): void {
+  const c = getCtx();
+  if (c && c.state === "suspended") void c.resume();
+}
+
+export function setMuted(value: boolean): void {
+  muted = value;
+}
+
+function tone(freq: number, duration: number, type: OscillatorType, volume: number): void {
+  if (muted) return;
+  const c = getCtx();
+  if (!c) return;
+  const now = c.currentTime;
+  const osc = c.createOscillator();
+  const gain = c.createGain();
+  osc.type = type;
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  gain.connect(c.destination);
+  // Short attack/release envelope so notes don't click.
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(volume, now + 0.015);
+  gain.gain.setValueAtTime(volume, Math.max(now + 0.015, now + duration - 0.05));
+  gain.gain.linearRampToValueAtTime(0, now + duration);
+  osc.start(now);
+  osc.stop(now + duration + 0.02);
+}
+
+// Fixed-length tone, used for automatic sequence playback.
+export function playPad(pad: number, duration = 0.4): void {
+  tone(PAD_FREQS[pad] ?? 300, duration, "sine", 0.22);
+}
+
+export function playError(): void {
+  tone(90, 0.5, "sawtooth", 0.18);
+}
+
+// Sustained tones for the player's own presses: the note rings for as long as
+// the pad is held. Keyed by pad so multiple held pads each get their own voice.
+const held = new Map<number, { osc: OscillatorNode; gain: GainNode }>();
+
+export function startPad(pad: number): void {
+  if (muted) return;
+  const c = getCtx();
+  if (!c) return;
+  stopPad(pad); // avoid stacking duplicate voices
+  const now = c.currentTime;
+  const osc = c.createOscillator();
+  const gain = c.createGain();
+  osc.type = "sine";
+  osc.frequency.value = PAD_FREQS[pad] ?? 300;
+  osc.connect(gain);
+  gain.connect(c.destination);
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(0.22, now + 0.015);
+  osc.start(now);
+  held.set(pad, { osc, gain });
+}
+
+export function stopPad(pad: number): void {
+  const c = getCtx();
+  const voice = held.get(pad);
+  if (!c || !voice) return;
+  held.delete(pad);
+  const now = c.currentTime;
+  // Short release so cutting the note doesn't click.
+  voice.gain.gain.cancelScheduledValues(now);
+  voice.gain.gain.setValueAtTime(voice.gain.gain.value, now);
+  voice.gain.gain.linearRampToValueAtTime(0, now + 0.04);
+  voice.osc.stop(now + 0.06);
+}
+
+export function stopAllPads(): void {
+  for (const pad of Array.from(held.keys())) stopPad(pad);
+}

--- a/src/app/playgrounds/simon/_lib/useBestScore.ts
+++ b/src/app/playgrounds/simon/_lib/useBestScore.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+// Persisted best round for Echo. Same-tab-notify pattern: the native `storage`
+// event only fires in *other* tabs, so we keep our own listener set.
+
+const KEY = "simon-best";
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+function getSnapshot(): number {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function useBestScore() {
+  const best = useSyncExternalStore(subscribe, getSnapshot, () => 0);
+
+  // Store `round` only when it beats the record. Returns true on a new best.
+  const saveIfBest = useCallback((round: number): boolean => {
+    if (round <= getSnapshot()) return false;
+    try {
+      window.localStorage.setItem(KEY, String(round));
+    } catch {
+      // Storage unavailable (private mode etc.); keep playing regardless.
+    }
+    listeners.forEach((l) => l());
+    return true;
+  }, []);
+
+  return { best, saveIfBest };
+}

--- a/src/app/playgrounds/simon/opengraph-image.tsx
+++ b/src/app/playgrounds/simon/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Echo";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Echo",
+  "Watch the pattern of colours and tones, then tap it back. It grows every round.",
+);

--- a/src/app/playgrounds/simon/page.tsx
+++ b/src/app/playgrounds/simon/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { Simon } from "./_components/Simon";
+
+const description =
+  "A Simon memory game. Watch the pattern of colours and tones, then tap it back. It grows every round.";
+
+export const metadata: Metadata = {
+  title: "Echo | Playground",
+  description,
+  openGraph: {
+    title: "Echo",
+    description,
+  },
+};
+
+export default function SimonPage() {
+  return <Simon />;
+}


### PR DESCRIPTION
### What

Adds a new touch-first playground at `/playgrounds/simon`: a Simon memory game called **Echo**.

- Classic Simon disc: an SVG donut of four coloured quadrants (green/red/yellow/blue) that light up. Big, scalable touch targets driven by pointer events, so mouse and touch share one code path.
- Each colour has its own tone (G3/C4/E4/G4), so the pattern is audible as well as visual. Dependency-free Web Audio, with the context resumed lazily on the first tap to satisfy mobile autoplay, plus a mute toggle.
- Watch the sequence, tap it back; it grows by one each round. Constant playback speed with 3 lives: a wrong tap costs a life and replays the current sequence, 0 lives ends the game.
- Score = highest round reached, best persisted to `localStorage`. Homepage card auto-flashes a demo pattern; OpenGraph image included.

### Structure

Pure sequence logic (`nextStep`/`extend`/`isInputCorrect`) lives in `_lib/game.ts` and is unit tested. The interactive flow (playback timers, input matching, lives) is plain React state in `Simon.tsx` with all timeouts tracked in a ref and cleared on unmount. No XState (playback/audio timing lives in effects regardless, so a machine adds ceremony without much gain).

### Risk / testing

- `pnpm test` green (6 new unit tests: sequence growth/immutability, rng bucketing, input matching).
- `pnpm build` + typecheck pass; the route prerenders static.
- Lint introduces no new problems.
- Audio and playback timing are client-side, so this was smoke-tested via the static prerender rather than driven end-to-end. Worth a quick manual playtest: sound-per-colour, the 3-lives/replay behaviour, mute, and taps on a real touch screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)