### PR TITLE
fix: resolve set-state-in-effect lint errors

### DIFF
--- a/src/app/playgrounds/connect-four/_components/ConnectFour.tsx
+++ b/src/app/playgrounds/connect-four/_components/ConnectFour.tsx
@@ -95,7 +95,10 @@ export function ConnectFour() {
 
   useEffect(() => {
     if (!loading && isLoaded() && game.currentPlayer !== humanPlayer && !result && !thinking) {
-      aiMove(game);
+      // Defer a tick so the AI turn's state updates don't fire synchronously
+      // inside the effect (and so a fast reset can cancel a queued move).
+      const id = setTimeout(() => aiMove(game), 0);
+      return () => clearTimeout(id);
     }
   }, [loading, game, humanPlayer, result, thinking, aiMove]);
 

--- a/src/app/playgrounds/food-analyzer/_hooks/useAnalysisHistory.ts
+++ b/src/app/playgrounds/food-analyzer/_hooks/useAnalysisHistory.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect } from "react";
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
 import type { FoodAnalysis } from "../types";
 
 const STORAGE_KEY = "food-analyzer-history";
@@ -11,60 +13,86 @@ export interface HistoryItem {
   analysis: FoodAnalysis;
 }
 
-export function useAnalysisHistory() {
-  const [history, setHistory] = useState<HistoryItem[]>([]);
+// Same-tab change notifications: the native `storage` event only fires in
+// other tabs, so we keep our own listener set and emit on write.
+const listeners = new Set<() => void>();
 
-  useEffect(() => {
-    // Load history from localStorage on mount
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+// getSnapshot must return a stable reference between renders or React loops,
+// so we memoise the parsed value against the raw string.
+let cache: { raw: string | null; value: HistoryItem[] } = {
+  raw: null,
+  value: [],
+};
+
+// Stable empty reference for the server (and storage-unavailable) snapshot.
+const EMPTY: HistoryItem[] = [];
+
+function getSnapshot(): HistoryItem[] {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    raw = null;
+  }
+  if (cache.raw !== raw) {
+    let value: HistoryItem[] = [];
     try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        setHistory(JSON.parse(stored));
-      }
-    } catch (error) {
-      console.error("Failed to load history:", error);
+      value = raw ? (JSON.parse(raw) as HistoryItem[]) : [];
+    } catch {
+      value = [];
     }
-  }, []);
+    cache = { raw, value };
+  }
+  return cache.value;
+}
 
-  const addToHistory = (input: string, analysis: FoodAnalysis) => {
+function write(items: HistoryItem[]) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch (error) {
+    console.error("Failed to save history:", error);
+  }
+  emit();
+}
+
+export function useAnalysisHistory() {
+  const history = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+
+  const addToHistory = useCallback((input: string, analysis: FoodAnalysis) => {
     const newItem: HistoryItem = {
       id: Date.now().toString(),
       timestamp: Date.now(),
       input: input.substring(0, 100), // Truncate long inputs
       analysis,
     };
+    write([newItem, ...getSnapshot()].slice(0, MAX_HISTORY));
+  }, []);
 
-    setHistory((prev) => {
-      const updated = [newItem, ...prev].slice(0, MAX_HISTORY);
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-      } catch (error) {
-        console.error("Failed to save history:", error);
-      }
-      return updated;
-    });
-  };
+  const removeFromHistory = useCallback((id: string) => {
+    write(getSnapshot().filter((item) => item.id !== id));
+  }, []);
 
-  const removeFromHistory = (id: string) => {
-    setHistory((prev) => {
-      const updated = prev.filter((item) => item.id !== id);
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-      } catch (error) {
-        console.error("Failed to save history:", error);
-      }
-      return updated;
-    });
-  };
-
-  const clearHistory = () => {
-    setHistory([]);
+  const clearHistory = useCallback(() => {
     try {
-      localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
       console.error("Failed to clear history:", error);
     }
-  };
+    emit();
+  }, []);
 
   return {
     history,

--- a/src/app/playgrounds/lights-out/Preview.tsx
+++ b/src/app/playgrounds/lights-out/Preview.tsx
@@ -6,19 +6,15 @@ import { useIntersectionObserver } from "../../_hooks";
 export function LightsOutPreview() {
   const containerRef = useRef<HTMLDivElement>(null);
   const isVisible = useIntersectionObserver(containerRef);
-  const [grid, setGrid] = useState<boolean[][]>([]);
+  const [grid, setGrid] = useState<boolean[][]>(() =>
+    Array(3)
+      .fill(null)
+      .map(() => Array(3).fill(false))
+  );
   const intervalRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => {
-    // Initialize 3x3 grid
-    const initialGrid = Array(3)
-      .fill(null)
-      .map(() => Array(3).fill(false));
-    setGrid(initialGrid);
-  }, []);
-
-  useEffect(() => {
-    if (!isVisible || grid.length === 0) {
+    if (!isVisible) {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
@@ -48,7 +44,7 @@ export function LightsOutPreview() {
         clearInterval(intervalRef.current);
       }
     };
-  }, [isVisible, grid.length]);
+  }, [isVisible]);
 
   return (
     <div


### PR DESCRIPTION
### What

Clears the three `react-hooks/set-state-in-effect` ESLint errors (all effects that called `setState` synchronously):

- **lights-out Preview** — seeded a static 3×3 grid via an effect; moved to a `useState` lazy initializer, which also lets us drop a now-dead `grid.length` guard and effect dependency.
- **food-analyzer `useAnalysisHistory`** — loaded history from localStorage in an on-mount effect; rewrote around `useSyncExternalStore`, matching the pattern the game hooks (`memory`, `simon`, `chicken-crossing`) already use. Same-tab writes notify via a local listener set; snapshots are memoised against the raw string so the reference stays stable.
- **connect-four** — deferred the AI-move kickoff by a tick (`setTimeout(..., 0)` with cleanup) so its state updates no longer fire synchronously inside the effect, and a fast reset cancels a queued move.

### Why

`pnpm lint` reported 3 errors. Left unaddressed they mask new violations and block a clean lint gate.

### Risk / testing

Behavioural code, no test coverage on these paths. Manual checks: lights-out preview still animates when scrolled into view; connect-four AI still responds after a human move and on new-game/reset; food-analyzer history still loads, adds, removes, and clears. `pnpm lint` now 0 errors, `tsc --noEmit` clean, 82 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)