### PR TITLE
feat: reveal the Recall board for five seconds before play

### DIFF
--- a/src/app/playgrounds/memory/_components/Memory/Card.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Card.tsx
@@ -6,11 +6,13 @@ import type { Card as CardType } from "../../_lib/game";
 interface CardProps {
   card: CardType;
   disabled: boolean;
+  // Whole board revealed during the memorise phase; overrides per-card state.
+  preview: boolean;
   onFlip: (id: number) => void;
 }
 
-export function Card({ card, disabled, onFlip }: CardProps) {
-  const faceUp = card.isFlipped || card.isMatched;
+export function Card({ card, disabled, preview, onFlip }: CardProps) {
+  const faceUp = preview || card.isFlipped || card.isMatched;
 
   return (
     <button

--- a/src/app/playgrounds/memory/_components/Memory/Memory.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Memory.tsx
@@ -186,20 +186,25 @@ export function Memory() {
           <Stat label="Pairs" value={`${state.matched} / ${pairs}`} />
         </div>
 
-        {/* Preview countdown: shown while the board is revealed to memorise. */}
-        {preview && (
-          <div
-            className="mb-6 flex items-center justify-between gap-3 rounded-md border-[3px] border-black bg-black px-4 py-3 text-[#fffef5]"
-            style={{ animation: "matchpop 0.35s ease-out" }}
-          >
-            <p className="font-mono text-[11px] uppercase tracking-[0.3em]">
-              memorise the board
-            </p>
-            <p className="font-roboto-slab text-2xl font-black leading-none tabular-nums">
-              {countdown}s
-            </p>
-          </div>
-        )}
+        {/* Status strip: always present so the board never jumps between
+            phases. Bold black bar while memorising, a calm hint during play. */}
+        <div
+          className={`mb-6 flex items-center justify-between gap-3 rounded-md border-[3px] border-black px-4 py-3 transition-colors ${
+            preview ? "bg-black text-[#fffef5]" : "bg-[#fffef5] text-black"
+          }`}
+          style={preview ? { animation: "matchpop 0.35s ease-out" } : undefined}
+        >
+          <p className="font-mono text-[11px] uppercase tracking-[0.3em]">
+            {preview
+              ? "memorise the board"
+              : won
+                ? "board cleared"
+                : "find the pairs"}
+          </p>
+          <p className="font-roboto-slab text-2xl font-black leading-none tabular-nums">
+            {preview ? `${countdown}s` : won ? "done" : `${pairs - state.matched} left`}
+          </p>
+        </div>
 
         {/* Board */}
         <div className="relative">

--- a/src/app/playgrounds/memory/_components/Memory/Memory.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Memory.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import {
   DIFFICULTIES,
+  PREVIEW_SECONDS,
   buildDeck,
   createInitialState,
   gameReducer,
@@ -40,6 +41,7 @@ export function Memory() {
   );
 
   const [elapsed, setElapsed] = useState(0);
+  const [countdown, setCountdown] = useState(PREVIEW_SECONDS);
   const [newBest, setNewBest] = useState(false);
   const { best, saveIfBest } = useBestScore(difficulty);
   const startRef = useRef<number | null>(null);
@@ -52,10 +54,30 @@ export function Memory() {
     startRef.current = null;
     savedRef.current = false;
     setElapsed(0);
+    setCountdown(PREVIEW_SECONDS);
     setNewBest(false);
     setDifficulty(d);
     dispatch({ type: "NEW_GAME", difficulty: d, cards: buildDeck(d) });
   }, []);
+
+  // Preview: reveal the whole board, count down, then hide it and start play.
+  // Re-runs per deal (cards identity changes) so a new game restarts the peek.
+  // The countdown itself is reset in newGame (and via initial state on mount).
+  useEffect(() => {
+    if (state.status !== "preview") return;
+    const tick = window.setInterval(
+      () => setCountdown((c) => Math.max(0, c - 1)),
+      1000,
+    );
+    const done = window.setTimeout(
+      () => dispatch({ type: "START_PLAY" }),
+      PREVIEW_SECONDS * 1000,
+    );
+    return () => {
+      window.clearInterval(tick);
+      window.clearTimeout(done);
+    };
+  }, [state.status, state.cards]);
 
   // Clock: ticks from the first flip until the board is won.
   useEffect(() => {
@@ -106,6 +128,7 @@ export function Memory() {
   }, [state.status, state.moves, elapsed, saveIfBest]);
 
   const won = state.status === "won";
+  const preview = state.status === "preview";
 
   return (
     <div
@@ -163,6 +186,21 @@ export function Memory() {
           <Stat label="Pairs" value={`${state.matched} / ${pairs}`} />
         </div>
 
+        {/* Preview countdown: shown while the board is revealed to memorise. */}
+        {preview && (
+          <div
+            className="mb-6 flex items-center justify-between gap-3 rounded-md border-[3px] border-black bg-black px-4 py-3 text-[#fffef5]"
+            style={{ animation: "matchpop 0.35s ease-out" }}
+          >
+            <p className="font-mono text-[11px] uppercase tracking-[0.3em]">
+              memorise the board
+            </p>
+            <p className="font-roboto-slab text-2xl font-black leading-none tabular-nums">
+              {countdown}s
+            </p>
+          </div>
+        )}
+
         {/* Board */}
         <div className="relative">
           <div
@@ -178,7 +216,12 @@ export function Memory() {
                   animationDelay: `${Math.min(i * 25, 500)}ms`,
                 }}
               >
-                <Card card={card} disabled={state.locked} onFlip={(id) => dispatch({ type: "FLIP", id })} />
+                <Card
+                  card={card}
+                  disabled={state.locked}
+                  preview={preview}
+                  onFlip={(id) => dispatch({ type: "FLIP", id })}
+                />
               </div>
             ))}
           </div>

--- a/src/app/playgrounds/memory/_components/Memory/Memory.tsx
+++ b/src/app/playgrounds/memory/_components/Memory/Memory.tsx
@@ -157,7 +157,7 @@ export function Memory() {
             </div>
 
             {/* Difficulty selector */}
-            <div className="flex overflow-hidden rounded-md border-[3px] border-black">
+            <div className="flex w-full overflow-hidden rounded-md border-[3px] border-black sm:w-auto">
               {ORDER.map((d) => {
                 const active = difficulty === d;
                 return (
@@ -165,7 +165,7 @@ export function Memory() {
                     key={d}
                     type="button"
                     onClick={() => newGame(d)}
-                    className={`px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors sm:px-4 ${
+                    className={`flex-1 px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors sm:flex-none sm:px-4 ${
                       active
                         ? "bg-black text-[#fffef5]"
                         : "bg-transparent text-black hover:bg-black/10"

--- a/src/app/playgrounds/memory/_lib/game.test.ts
+++ b/src/app/playgrounds/memory/_lib/game.test.ts
@@ -156,6 +156,36 @@ describe("gameReducer", () => {
     expect(next.cards).toBe(deck);
     expect(next.moves).toBe(0);
     expect(next.firstPick).toBeNull();
-    expect(next.status).toBe("playing");
+    expect(next.status).toBe("preview");
+    expect(next.locked).toBe(true);
+  });
+
+  it("starts a new game in the locked preview phase", () => {
+    const state = createInitialState("easy", seededRng(1));
+    expect(state.status).toBe("preview");
+    expect(state.locked).toBe(true);
+  });
+
+  it("ignores flips during the preview phase", () => {
+    const state = createInitialState("easy", seededRng(1));
+    expect(gameReducer(state, { type: "FLIP", id: 0 })).toBe(state);
+  });
+
+  it("unlocks the board on START_PLAY", () => {
+    let state = createInitialState("easy", seededRng(1));
+    state = gameReducer(state, { type: "START_PLAY" });
+    expect(state.status).toBe("playing");
+    expect(state.locked).toBe(false);
+
+    // First pick now registers.
+    state = gameReducer(state, { type: "FLIP", id: 0 });
+    expect(state.firstPick).toBe(0);
+  });
+
+  it("ignores START_PLAY once play has begun", () => {
+    const state = gameReducer(createInitialState("easy", seededRng(1)), {
+      type: "START_PLAY",
+    });
+    expect(gameReducer(state, { type: "START_PLAY" })).toBe(state);
   });
 });

--- a/src/app/playgrounds/memory/_lib/game.ts
+++ b/src/app/playgrounds/memory/_lib/game.ts
@@ -18,6 +18,9 @@ export const DIFFICULTIES: Record<Difficulty, DifficultyConfig> = {
   hard: { label: "Hard", pairs: 15, columns: 6 },
 };
 
+// Seconds the whole board is revealed before it hides and play begins.
+export const PREVIEW_SECONDS = 5;
+
 export interface Card {
   id: number;
   shape: ShapeKey;
@@ -32,13 +35,16 @@ export interface GameState {
   secondPick: number | null;
   moves: number;
   matched: number;
-  status: "playing" | "won";
-  // Locked while a mismatched pair is showing, so further clicks are ignored.
+  // "preview": whole board is revealed for memorising, no picks allowed yet.
+  status: "preview" | "playing" | "won";
+  // Locked while a mismatched pair is showing (or during preview), so further
+  // clicks are ignored.
   locked: boolean;
 }
 
 export type GameAction =
   | { type: "NEW_GAME"; difficulty: Difficulty; cards: Card[] }
+  | { type: "START_PLAY" }
   | { type: "FLIP"; id: number }
   | { type: "CLEAR_MISMATCH" };
 
@@ -79,8 +85,8 @@ export function createInitialState(
     secondPick: null,
     moves: 0,
     matched: 0,
-    status: "playing",
-    locked: false,
+    status: "preview",
+    locked: true,
   };
 }
 
@@ -94,12 +100,16 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         secondPick: null,
         moves: 0,
         matched: 0,
-        status: "playing",
-        locked: false,
+        status: "preview",
+        locked: true,
       };
 
+    case "START_PLAY":
+      if (state.status !== "preview") return state;
+      return { ...state, status: "playing", locked: false };
+
     case "FLIP": {
-      if (state.locked || state.status === "won") return state;
+      if (state.locked || state.status !== "playing") return state;
 
       const card = state.cards.find((c) => c.id === action.id);
       if (!card || card.isMatched || card.isFlipped) return state;


### PR DESCRIPTION
### What

Adds a preview phase to the Recall memory game:

- On every new deal, the whole board is revealed face-up for five seconds.
- A "Memorise the board" banner shows a live countdown during the peek.
- When the countdown ends, the cards flip down and play begins.

Implementation:

- New `"preview"` status on the reducer (board locked, no picks allowed) plus a `START_PLAY` action that ends it.
- Face-up-during-preview is derived in the `Card` component from game status, so the deck state stays untouched and the existing flip-down animation is reused.
- Countdown reset lives in the `newGame` handler; the effect only owns the interval and the `START_PLAY` timeout.

### Why

Previously the board started fully hidden, so it was blind flipping until you stumbled onto pairs. The five-second reveal turns it into an actual memorise-the-positions challenge, which is the point of a recall game.