### PR TITLE
feat: add a Whack-a-Mole game that speeds up and scores you

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ import { LotteryPreview } from "./playgrounds/lottery/Preview";
 import { MemoryPreview } from "./playgrounds/memory/Preview";
 import { SimonPreview } from "./playgrounds/simon/Preview";
 import { ChickenCrossingPreview } from "./playgrounds/chicken-crossing/Preview";
+import { WhackAMolePreview } from "./playgrounds/whack-a-mole/Preview";
 
 type Category =
   | "Games"
@@ -39,6 +40,15 @@ const playgrounds = [
       "A Simon memory game. Watch the pattern of colours and tones, then tap it back. It grows every round.",
     href: "/playgrounds/simon",
     preview: SimonPreview,
+    category: "Games",
+  },
+  {
+    id: "whack-a-mole",
+    title: "Whack-a-Mole",
+    description:
+      "Bonk the moles before they duck away. They speed up as the round runs down. Beat your high score.",
+    href: "/playgrounds/whack-a-mole",
+    preview: WhackAMolePreview,
     category: "Games",
   },
   {

--- a/src/app/playgrounds/whack-a-mole/Preview.tsx
+++ b/src/app/playgrounds/whack-a-mole/Preview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useIntersectionObserver } from "../../_hooks";
+import { Mole } from "./_components/WhackAMole/Mole";
+
+// A fixed 3-hole scene; the moles pop up in sequence to hint at the mechanic.
+const HOLES = [0, 1, 2];
+
+export function WhackAMolePreview() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver(containerRef);
+  const [active, setActive] = useState(1);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const id = setInterval(() => setActive((a) => (a + 1) % HOLES.length), 700);
+    return () => clearInterval(id);
+  }, [isVisible]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-full w-full items-center justify-center bg-[#fffef5] p-5"
+      style={{
+        backgroundImage: `
+          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
+        `,
+        backgroundSize: "20px 20px",
+      }}
+    >
+      <div
+        className="flex items-end justify-center gap-3 rounded-lg border-[3px] border-black p-4"
+        style={{
+          backgroundColor: "#8fb45f",
+          backgroundImage:
+            "radial-gradient(rgba(255,255,255,0.14) 1.5px, transparent 1.5px)",
+          backgroundSize: "12px 12px",
+        }}
+      >
+        {HOLES.map((i) => {
+          const up = i === active;
+          return (
+            <div
+              key={i}
+              className="relative h-20 w-20 overflow-hidden rounded-2xl border-[3px] border-black"
+              style={{ backgroundColor: "#d9b98c" }}
+            >
+              <div className="absolute inset-x-[16%] bottom-[14%] top-[46%] rounded-[50%] border-[3px] border-black bg-[#3a2a1a]" />
+              <div
+                className="absolute inset-x-[20%] bottom-[16%] transition-transform duration-200 ease-out"
+                style={{ transform: up ? "translateY(0)" : "translateY(130%)" }}
+              >
+                <Mole hit={false} />
+              </div>
+              <div
+                className="absolute inset-x-0 bottom-0 h-[20%] rounded-t-[50%] border-t-[3px] border-black"
+                style={{ backgroundColor: "#c8a373" }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/playgrounds/whack-a-mole/_components/WhackAMole/Mole.tsx
+++ b/src/app/playgrounds/whack-a-mole/_components/WhackAMole/Mole.tsx
@@ -1,0 +1,76 @@
+// A cartoon mole drawn as an SVG so it stays crisp at any hole size. When
+// `hit` it screws its eyes shut and sticks its tongue out, sold with a little
+// starburst behind the head.
+export function Mole({ hit }: { hit: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className="h-full w-full drag-none"
+      aria-hidden="true"
+    >
+      {hit && (
+        <g stroke="#000" strokeWidth="3" strokeLinecap="round">
+          {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
+            <line
+              key={deg}
+              x1="50"
+              y1="42"
+              x2="50"
+              y2="20"
+              stroke="#f7c948"
+              transform={`rotate(${deg} 50 42)`}
+            />
+          ))}
+        </g>
+      )}
+
+      {/* ears */}
+      <circle cx="24" cy="40" r="9" fill="#7a4a28" stroke="#000" strokeWidth="4" />
+      <circle cx="76" cy="40" r="9" fill="#7a4a28" stroke="#000" strokeWidth="4" />
+
+      {/* body */}
+      <ellipse cx="50" cy="60" rx="33" ry="35" fill="#a56b43" stroke="#000" strokeWidth="4" />
+
+      {/* muzzle */}
+      <ellipse cx="50" cy="70" rx="21" ry="17" fill="#e8c9a0" stroke="#000" strokeWidth="3" />
+
+      {/* eyes */}
+      {hit ? (
+        <g stroke="#000" strokeWidth="4" strokeLinecap="round">
+          <line x1="33" y1="47" x2="43" y2="55" />
+          <line x1="43" y1="47" x2="33" y2="55" />
+          <line x1="57" y1="47" x2="67" y2="55" />
+          <line x1="67" y1="47" x2="57" y2="55" />
+        </g>
+      ) : (
+        <g>
+          <circle cx="38" cy="50" r="5.5" fill="#000" />
+          <circle cx="62" cy="50" r="5.5" fill="#000" />
+          <circle cx="40" cy="48" r="1.6" fill="#fffef5" />
+          <circle cx="64" cy="48" r="1.6" fill="#fffef5" />
+        </g>
+      )}
+
+      {/* nose */}
+      <circle cx="50" cy="64" r="5.5" fill="#ef3d2f" stroke="#000" strokeWidth="2" />
+
+      {/* tongue when bonked */}
+      {hit && (
+        <path
+          d="M46 74 q4 10 8 0 z"
+          fill="#ef3d2f"
+          stroke="#000"
+          strokeWidth="2"
+        />
+      )}
+
+      {/* whiskers */}
+      <g stroke="#000" strokeWidth="2" strokeLinecap="round">
+        <line x1="30" y1="68" x2="16" y2="65" />
+        <line x1="30" y1="72" x2="16" y2="73" />
+        <line x1="70" y1="68" x2="84" y2="65" />
+        <line x1="70" y1="72" x2="84" y2="73" />
+      </g>
+    </svg>
+  );
+}

--- a/src/app/playgrounds/whack-a-mole/_components/WhackAMole/WhackAMole.tsx
+++ b/src/app/playgrounds/whack-a-mole/_components/WhackAMole/WhackAMole.tsx
@@ -1,0 +1,541 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  GAME_MS,
+  GAME_SECONDS,
+  HOLES,
+  moleLifetime,
+  multiplier,
+  pickHole,
+  spawnInterval,
+} from "../../_lib/game";
+import { createSounds, type Sounds } from "../../_lib/audio";
+import { useHighScore } from "../../_lib/useHighScore";
+import { Mole } from "./Mole";
+
+type Status = "idle" | "playing" | "over";
+type Phase = "up" | "hit";
+type Hole = { id: number; phase: Phase } | null;
+type Float = { id: number; idx: number; points: number };
+
+// How long a bonked mole shows its dazed face before dropping.
+const HIT_MS = 350;
+// A breather after the round ends before "Play again" accepts a tap, so a
+// stray whack landing on the overlay doesn't instantly restart.
+const RESTART_LOCK_MS = 900;
+
+const emptyBoard = (): Hole[] => Array.from({ length: HOLES }, () => null);
+const INDICES = Array.from({ length: HOLES }, (_, i) => i);
+
+export function WhackAMole() {
+  const [status, setStatus] = useState<Status>("idle");
+  const [holes, setHoles] = useState<Hole[]>(emptyBoard);
+  const [score, setScore] = useState(0);
+  const [combo, setCombo] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(GAME_SECONDS);
+  const [floats, setFloats] = useState<Float[]>([]);
+  const [newHigh, setNewHigh] = useState(false);
+  const [canRestart, setCanRestart] = useState(true);
+  const [muted, setMuted] = useState(false);
+  const [summary, setSummary] = useState({
+    hits: 0,
+    accuracy: 100,
+    bestStreak: 0,
+  });
+  const { high, saveIfHigh } = useHighScore();
+
+  // The board is driven imperatively by timers, so we keep a ref mirror as the
+  // source of truth and push it into state purely for rendering. Scheduling
+  // timeouts inside a setState updater would double-fire under StrictMode.
+  const holesRef = useRef<Hole[]>(emptyBoard());
+  const statusRef = useRef<Status>("idle");
+  const mutedRef = useRef(false);
+  const startRef = useRef<number | null>(null);
+  const idRef = useRef(0);
+  const floatIdRef = useRef(0);
+
+  // Live tallies read by timer callbacks and the end screen.
+  const scoreRef = useRef(0);
+  const comboRef = useRef(0);
+  const bestStreakRef = useRef(0);
+  const hitsRef = useRef(0);
+  const missesRef = useRef(0);
+
+  const spawnRef = useRef<number | null>(null);
+  const clockRef = useRef<number | null>(null);
+  const restartRef = useRef<number | null>(null);
+  const hideRef = useRef(new Map<number, number>());
+  const bonkRef = useRef(new Map<number, number>());
+  const floatTimersRef = useRef(new Set<number>());
+  const soundsRef = useRef<Sounds | null>(null);
+
+  const commit = useCallback((idx: number, value: Hole) => {
+    const next = holesRef.current.slice();
+    next[idx] = value;
+    holesRef.current = next;
+    setHoles(next);
+  }, []);
+
+  const clearAllTimers = useCallback(() => {
+    if (spawnRef.current !== null) window.clearTimeout(spawnRef.current);
+    if (clockRef.current !== null) window.clearInterval(clockRef.current);
+    if (restartRef.current !== null) window.clearTimeout(restartRef.current);
+    spawnRef.current = null;
+    clockRef.current = null;
+    restartRef.current = null;
+    hideRef.current.forEach((t) => window.clearTimeout(t));
+    bonkRef.current.forEach((t) => window.clearTimeout(t));
+    floatTimersRef.current.forEach((t) => window.clearTimeout(t));
+    hideRef.current.clear();
+    bonkRef.current.clear();
+    floatTimersRef.current.clear();
+  }, []);
+
+  const elapsed = useCallback(
+    () => (startRef.current === null ? 0 : Date.now() - startRef.current),
+    [],
+  );
+
+  const popMole = useCallback(() => {
+    if (statusRef.current !== "playing") return;
+    const occupied = holesRef.current.map((h) => h !== null);
+    const idx = pickHole(occupied);
+    if (idx === -1) return;
+
+    const id = ++idRef.current;
+    commit(idx, { id, phase: "up" });
+
+    // Duck back on its own if it isn't whacked in time (a miss: resets streak).
+    hideRef.current.set(
+      idx,
+      window.setTimeout(() => {
+        hideRef.current.delete(idx);
+        const current = holesRef.current[idx];
+        if (current && current.id === id) {
+          commit(idx, null);
+          comboRef.current = 0;
+          setCombo(0);
+          missesRef.current += 1;
+          if (!mutedRef.current) soundsRef.current?.miss();
+        }
+      }, moleLifetime(elapsed())),
+    );
+  }, [commit, elapsed]);
+
+  const scheduleSpawn = useCallback(() => {
+    // Self-scheduling loop: each spawn queues the next at the current tempo,
+    // which tightens as the round wears on.
+    const loop = () => {
+      spawnRef.current = window.setTimeout(() => {
+        if (statusRef.current !== "playing") return;
+        popMole();
+        loop();
+      }, spawnInterval(elapsed()));
+    };
+    loop();
+  }, [popMole, elapsed]);
+
+  const endGame = useCallback(() => {
+    if (statusRef.current !== "playing") return;
+    clearAllTimers();
+    holesRef.current = emptyBoard();
+    setHoles(holesRef.current);
+    setFloats([]);
+    statusRef.current = "over";
+    setStatus("over");
+    setTimeLeft(0);
+    const shots = hitsRef.current + missesRef.current;
+    setSummary({
+      hits: hitsRef.current,
+      accuracy: shots === 0 ? 100 : Math.round((hitsRef.current / shots) * 100),
+      bestStreak: bestStreakRef.current,
+    });
+    setNewHigh(saveIfHigh(scoreRef.current));
+    // Lock the "Play again" button briefly against end-of-round mashing.
+    setCanRestart(false);
+    restartRef.current = window.setTimeout(
+      () => setCanRestart(true),
+      RESTART_LOCK_MS,
+    );
+  }, [clearAllTimers, saveIfHigh]);
+
+  const whack = useCallback(
+    (idx: number) => {
+      if (statusRef.current !== "playing") return;
+      const hole = holesRef.current[idx];
+      if (!hole || hole.phase !== "up") return;
+
+      const hideTimer = hideRef.current.get(idx);
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+        hideRef.current.delete(idx);
+      }
+
+      commit(idx, { id: hole.id, phase: "hit" });
+
+      comboRef.current += 1;
+      if (comboRef.current > bestStreakRef.current) {
+        bestStreakRef.current = comboRef.current;
+      }
+      const points = multiplier(comboRef.current);
+      scoreRef.current += points;
+      hitsRef.current += 1;
+      setScore(scoreRef.current);
+      setCombo(comboRef.current);
+      if (!mutedRef.current) soundsRef.current?.hit(points);
+
+      // Floating "+N" over the whacked hole.
+      const fid = ++floatIdRef.current;
+      setFloats((prev) => [...prev, { id: fid, idx, points }]);
+      const floatTimer = window.setTimeout(() => {
+        floatTimersRef.current.delete(floatTimer);
+        setFloats((prev) => prev.filter((f) => f.id !== fid));
+      }, 650);
+      floatTimersRef.current.add(floatTimer);
+
+      bonkRef.current.set(
+        idx,
+        window.setTimeout(() => {
+          bonkRef.current.delete(idx);
+          const current = holesRef.current[idx];
+          if (current && current.id === hole.id) commit(idx, null);
+        }, HIT_MS),
+      );
+    },
+    [commit],
+  );
+
+  const start = useCallback(() => {
+    clearAllTimers();
+    holesRef.current = emptyBoard();
+    setHoles(holesRef.current);
+    setFloats([]);
+    idRef.current = 0;
+    scoreRef.current = 0;
+    comboRef.current = 0;
+    bestStreakRef.current = 0;
+    hitsRef.current = 0;
+    missesRef.current = 0;
+    setScore(0);
+    setCombo(0);
+    setTimeLeft(GAME_SECONDS);
+    setNewHigh(false);
+    setCanRestart(true);
+    startRef.current = Date.now();
+    statusRef.current = "playing";
+    setStatus("playing");
+
+    // Unlock audio on this user gesture so the first hit isn't silent.
+    if (!soundsRef.current) soundsRef.current = createSounds();
+    if (!mutedRef.current) soundsRef.current.unlock();
+
+    // A wall-clock tick keeps the countdown honest even if a frame is dropped,
+    // and ends the round without side-effecting inside a state updater.
+    clockRef.current = window.setInterval(() => {
+      const remaining = Math.max(0, GAME_SECONDS - Math.floor(elapsed() / 1000));
+      setTimeLeft(remaining);
+      if (elapsed() >= GAME_MS) endGame();
+    }, 200);
+
+    popMole();
+    scheduleSpawn();
+  }, [clearAllTimers, elapsed, endGame, popMole, scheduleSpawn]);
+
+  const toggleMute = useCallback(() => {
+    setMuted((m) => {
+      mutedRef.current = !m;
+      return !m;
+    });
+  }, []);
+
+  // Tidy up any live timers if the component unmounts mid-round.
+  useEffect(() => clearAllTimers, [clearAllTimers]);
+
+  const playing = status === "playing";
+  const over = status === "over";
+  const mult = multiplier(combo);
+
+  return (
+    <div
+      className="min-h-full"
+      style={{
+        backgroundColor: "#fffef5",
+        backgroundImage: `
+          linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)
+        `,
+        backgroundSize: "32px 32px",
+      }}
+    >
+      <div className="mx-auto max-w-2xl px-4 py-8 sm:py-12">
+        {/* Header */}
+        <header className="mb-8">
+          <div className="mb-4 h-1 bg-black" />
+          <div>
+            <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-black/50">
+              they get faster · you get flustered
+            </p>
+            <h1 className="font-roboto-slab text-[clamp(3rem,10vw,5.5rem)] font-black leading-[0.85] tracking-tight text-black">
+              Whack-a-Mole
+            </h1>
+          </div>
+        </header>
+
+        {/* Stat bar */}
+        <div className="mb-6 grid grid-cols-3 gap-px overflow-hidden rounded-md border-[3px] border-black bg-black">
+          <Stat label="Score" value={String(score)} />
+          <Stat
+            label="Time"
+            value={`${timeLeft}s`}
+            accent={playing && timeLeft <= 5}
+          />
+          <Stat label="Best" value={String(high)} />
+        </div>
+
+        {/* Board */}
+        <div className="relative">
+          {/* Field: dirt holes sitting in the grass. */}
+          <div
+            className="rounded-lg border-[3px] border-black p-3 sm:p-4"
+            style={{
+              backgroundColor: "#8fb45f",
+              backgroundImage:
+                "radial-gradient(rgba(255,255,255,0.14) 1.5px, transparent 1.5px)",
+              backgroundSize: "14px 14px",
+            }}
+          >
+            <div
+              className={`grid grid-cols-3 gap-3 sm:gap-4 ${
+                playing ? "" : "pointer-events-none"
+              }`}
+            >
+              {holes.map((hole, i) => (
+                <HoleCell key={i} hole={hole} onWhack={() => whack(i)} />
+              ))}
+            </div>
+          </div>
+
+          {/* Score floats, aligned to the field with matching padding + grid. */}
+          <div className="pointer-events-none absolute inset-0 p-3 sm:p-4">
+            <div className="grid h-full grid-cols-3 gap-3 sm:gap-4">
+              {INDICES.map((i) => (
+                <div key={i} className="relative">
+                  {floats
+                    .filter((f) => f.idx === i)
+                    .map((f) => (
+                      <span
+                        key={f.id}
+                        className="absolute left-1/2 top-1/2 -translate-x-1/2 font-roboto-slab text-2xl font-black text-[#fffef5] sm:text-3xl"
+                        style={{
+                          animation: "score-float 0.65s ease-out forwards",
+                          textShadow: "2px 2px 0 rgba(0,0,0,0.9)",
+                        }}
+                      >
+                        +{f.points}
+                      </span>
+                    ))}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Streak badge */}
+          {playing && combo >= 2 && (
+            <div
+              key={combo}
+              className="pointer-events-none absolute -top-3 right-2 z-20 rounded-md border-[3px] border-black bg-[#ef3d2f] px-3 py-1 text-center shadow-[3px_3px_0_rgba(0,0,0,1)]"
+              style={{ animation: "combo-pop 0.25s ease-out" }}
+            >
+              <div className="font-mono text-[9px] uppercase tracking-widest text-[#fffef5]/80">
+                streak {combo}
+              </div>
+              <div className="font-roboto-slab text-lg font-black leading-none text-[#fffef5]">
+                {mult}&times;
+              </div>
+            </div>
+          )}
+
+          {/* Idle overlay */}
+          {status === "idle" && (
+            <Overlay>
+              <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-[#ef3d2f]">
+                {GAME_SECONDS} seconds
+              </p>
+              <h2 className="mb-3 font-roboto-slab text-4xl font-black leading-none text-black">
+                Ready?
+              </h2>
+              <p className="mb-4 font-mono text-sm text-black/70">
+                Bonk every mole that pokes its head out. Chain hits for a
+                multiplier. They speed up the longer you last.
+              </p>
+              <PrimaryButton onClick={start}>Start</PrimaryButton>
+            </Overlay>
+          )}
+
+          {/* Game over overlay */}
+          {over && (
+            <Overlay>
+              <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-[#ef3d2f]">
+                time&apos;s up
+              </p>
+              <h2 className="mb-1 font-roboto-slab text-5xl font-black leading-none text-black">
+                {score}
+              </h2>
+              <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.25em] text-black/50">
+                points
+              </p>
+              <p className="mb-4 font-mono text-sm text-black/70">
+                {summary.hits} hits · {summary.accuracy}% on target · best streak{" "}
+                {summary.bestStreak}
+                {newHigh && (
+                  <span className="mt-1 block font-bold text-[#ef3d2f]">
+                    new high score!
+                  </span>
+                )}
+              </p>
+              <PrimaryButton onClick={start} disabled={!canRestart}>
+                {canRestart ? "Play again" : "…"}
+              </PrimaryButton>
+            </Overlay>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={start}
+            className="rounded-md border-[3px] border-black bg-transparent px-4 py-2 font-mono text-xs uppercase tracking-widest text-black transition-colors hover:bg-black hover:text-[#fffef5]"
+          >
+            {playing ? "Restart" : "New game"}
+          </button>
+          <button
+            type="button"
+            onClick={toggleMute}
+            aria-pressed={muted}
+            className="rounded-md border-[3px] border-black bg-transparent px-3 py-2 font-mono text-[11px] uppercase tracking-widest text-black/60 transition-colors hover:bg-black hover:text-[#fffef5]"
+          >
+            {muted ? "sound off" : "sound on"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HoleCell({ hole, onWhack }: { hole: Hole; onWhack: () => void }) {
+  const up = hole !== null;
+  const hit = hole?.phase === "hit";
+
+  return (
+    <button
+      type="button"
+      // pointerdown beats click for a twitchy game, and cuts the tap delay on
+      // touch. preventDefault stops long-press selection while mashing.
+      onPointerDown={(e) => {
+        e.preventDefault();
+        onWhack();
+      }}
+      className="relative aspect-square touch-none select-none overflow-hidden rounded-2xl border-[3px] border-black"
+      style={{
+        backgroundColor: "#d9b98c",
+        backgroundImage:
+          "radial-gradient(rgba(0,0,0,0.08) 1.2px, transparent 1.2px)",
+        backgroundSize: "10px 10px",
+        cursor: up ? "pointer" : "default",
+      }}
+      aria-label={up ? "Whack the mole" : "Empty hole"}
+    >
+      {/* the hole itself */}
+      <div className="absolute inset-x-[16%] bottom-[14%] top-[46%] rounded-[50%] border-[3px] border-black bg-[#3a2a1a]" />
+
+      {/* mole rises out of the hole, clipped by the cell on the way down */}
+      <div
+        className="absolute inset-x-[20%] bottom-[16%] transition-transform duration-150 ease-out"
+        style={{
+          transform: up ? "translateY(0)" : "translateY(130%)",
+          animation: hit ? "mole-bonk 0.35s ease-in forwards" : undefined,
+        }}
+      >
+        <Mole hit={hit} />
+      </div>
+
+      {/* impact flash on a clean whack */}
+      {hit && (
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(circle at 50% 45%, rgba(247,201,72,0.75), transparent 60%)",
+          }}
+        />
+      )}
+
+      {/* front lip of the mound, drawn over the mole to hide its feet */}
+      <div
+        className="absolute inset-x-0 bottom-0 h-[20%] rounded-t-[50%] border-t-[3px] border-black"
+        style={{ backgroundColor: "#c8a373" }}
+      />
+    </button>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="bg-[#fffef5] px-3 py-3 text-center sm:py-4">
+      <div className="font-mono text-[10px] uppercase tracking-[0.25em] text-black/50">
+        {label}
+      </div>
+      <div
+        className={`font-roboto-slab text-2xl font-black leading-tight sm:text-3xl ${
+          accent ? "text-[#ef3d2f]" : "text-black"
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Overlay({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="absolute inset-0 z-10 flex items-center justify-center p-4">
+      <div
+        className="w-full max-w-sm rounded-lg border-[3px] border-black bg-[#fffef5] p-6 text-center shadow-[8px_8px_0_rgba(0,0,0,1)]"
+        style={{ animation: "matchpop 0.35s ease-out" }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="w-full rounded-md border-[3px] border-black bg-black px-4 py-3 font-mono text-xs uppercase tracking-widest text-[#fffef5] transition-transform hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:translate-y-0"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/playgrounds/whack-a-mole/_components/WhackAMole/index.tsx
+++ b/src/app/playgrounds/whack-a-mole/_components/WhackAMole/index.tsx
@@ -1,0 +1,1 @@
+export { WhackAMole } from "./WhackAMole";

--- a/src/app/playgrounds/whack-a-mole/_lib/audio.ts
+++ b/src/app/playgrounds/whack-a-mole/_lib/audio.ts
@@ -1,0 +1,68 @@
+// A tiny Web Audio synth so hits and misses have some punch without shipping
+// any sound files. Everything is guarded: if the API is missing or blocked we
+// just fall silent rather than throwing mid-game.
+
+type WindowWithWebkit = Window &
+  typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+
+export interface Sounds {
+  unlock: () => void;
+  hit: (mult: number) => void;
+  miss: () => void;
+}
+
+export function createSounds(): Sounds {
+  let ctx: AudioContext | null = null;
+
+  const ensure = (): AudioContext | null => {
+    try {
+      if (!ctx) {
+        const Ctor =
+          window.AudioContext || (window as WindowWithWebkit).webkitAudioContext;
+        if (!Ctor) return null;
+        ctx = new Ctor();
+      }
+      if (ctx.state === "suspended") void ctx.resume();
+      return ctx;
+    } catch {
+      return null;
+    }
+  };
+
+  // A short pitched blip with a fast exponential decay.
+  const blip = (
+    freq: number,
+    duration: number,
+    type: OscillatorType,
+    peak: number,
+  ) => {
+    const c = ensure();
+    if (!c) return;
+    const now = c.currentTime;
+    const osc = c.createOscillator();
+    const gain = c.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, now);
+    // A quick downward chirp gives the "thock" its shape.
+    osc.frequency.exponentialRampToValueAtTime(freq * 0.6, now + duration);
+    gain.gain.setValueAtTime(peak, now);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    osc.connect(gain).connect(c.destination);
+    osc.start(now);
+    osc.stop(now + duration);
+  };
+
+  return {
+    // Called from the start gesture so the context is unlocked up front.
+    unlock: () => {
+      ensure();
+    },
+    hit: (mult: number) => {
+      // Higher multipliers ring a little brighter.
+      blip(320 + mult * 70, 0.09, "square", 0.14);
+    },
+    miss: () => {
+      blip(150, 0.16, "sine", 0.08);
+    },
+  };
+}

--- a/src/app/playgrounds/whack-a-mole/_lib/game.test.ts
+++ b/src/app/playgrounds/whack-a-mole/_lib/game.test.ts
@@ -1,0 +1,88 @@
+import {
+  GAME_MS,
+  LIFETIME_END_MS,
+  LIFETIME_START_MS,
+  MAX_MULTIPLIER,
+  SPAWN_END_MS,
+  SPAWN_START_MS,
+  moleLifetime,
+  multiplier,
+  pickHole,
+  progress,
+  spawnInterval,
+} from "./game";
+
+describe("progress", () => {
+  it("is 0 at the start and 1 at the end", () => {
+    expect(progress(0)).toBe(0);
+    expect(progress(GAME_MS)).toBe(1);
+  });
+
+  it("clamps outside the round", () => {
+    expect(progress(-1000)).toBe(0);
+    expect(progress(GAME_MS * 2)).toBe(1);
+  });
+});
+
+describe("spawnInterval", () => {
+  it("starts slow and finishes fast", () => {
+    expect(spawnInterval(0)).toBe(SPAWN_START_MS);
+    expect(spawnInterval(GAME_MS)).toBe(SPAWN_END_MS);
+  });
+
+  it("never increases as the round goes on", () => {
+    let prev = Infinity;
+    for (let t = 0; t <= GAME_MS; t += GAME_MS / 10) {
+      const value = spawnInterval(t);
+      expect(value).toBeLessThanOrEqual(prev);
+      expect(value).toBeGreaterThanOrEqual(SPAWN_END_MS);
+      prev = value;
+    }
+  });
+});
+
+describe("moleLifetime", () => {
+  it("starts generous and finishes stingy", () => {
+    expect(moleLifetime(0)).toBe(LIFETIME_START_MS);
+    expect(moleLifetime(GAME_MS)).toBe(LIFETIME_END_MS);
+  });
+
+  it("stays within bounds across the round", () => {
+    for (let t = 0; t <= GAME_MS; t += GAME_MS / 10) {
+      const value = moleLifetime(t);
+      expect(value).toBeLessThanOrEqual(LIFETIME_START_MS);
+      expect(value).toBeGreaterThanOrEqual(LIFETIME_END_MS);
+    }
+  });
+});
+
+describe("multiplier", () => {
+  it("is 1x for no streak and the first tier of hits", () => {
+    expect(multiplier(0)).toBe(1);
+    expect(multiplier(1)).toBe(1);
+    expect(multiplier(5)).toBe(1);
+  });
+
+  it("steps up once per COMBO_STEP hits", () => {
+    expect(multiplier(6)).toBe(2);
+    expect(multiplier(11)).toBe(3);
+  });
+
+  it("caps at MAX_MULTIPLIER", () => {
+    expect(multiplier(1000)).toBe(MAX_MULTIPLIER);
+  });
+});
+
+describe("pickHole", () => {
+  it("only ever returns an empty hole", () => {
+    const occupied = [true, false, true, false, true];
+    // rand pinned to the top of the range picks the last free hole.
+    expect(pickHole(occupied, () => 0.999)).toBe(3);
+    // rand at the bottom picks the first free hole.
+    expect(pickHole(occupied, () => 0)).toBe(1);
+  });
+
+  it("returns -1 when the board is full", () => {
+    expect(pickHole([true, true, true])).toBe(-1);
+  });
+});

--- a/src/app/playgrounds/whack-a-mole/_lib/game.ts
+++ b/src/app/playgrounds/whack-a-mole/_lib/game.ts
@@ -1,0 +1,61 @@
+// Core timing for "Whack-a-Mole". Everything here is pure so the difficulty
+// ramp can be unit tested without wiring up timers or the DOM.
+
+export const HOLES = 9;
+export const GAME_SECONDS = 30;
+export const GAME_MS = GAME_SECONDS * 1000;
+
+// The round starts leisurely and winds up to frantic. Spawns come closer
+// together and moles duck away sooner as the clock runs down.
+export const SPAWN_START_MS = 800;
+export const SPAWN_END_MS = 300;
+export const LIFETIME_START_MS = 1050;
+export const LIFETIME_END_MS = 500;
+
+// Consecutive hits build a multiplier: every COMBO_STEP hits bumps it one
+// step, up to MAX_MULTIPLIER. A miss resets the streak to zero.
+export const COMBO_STEP = 5;
+export const MAX_MULTIPLIER = 5;
+
+function clamp01(n: number): number {
+  return Math.max(0, Math.min(1, n));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+// 0 at the first tick of the round, 1 by the final second.
+export function progress(elapsedMs: number): number {
+  return clamp01(elapsedMs / GAME_MS);
+}
+
+// Gap between mole spawns; shrinks over the round so they come thick and fast.
+export function spawnInterval(elapsedMs: number): number {
+  return Math.round(lerp(SPAWN_START_MS, SPAWN_END_MS, progress(elapsedMs)));
+}
+
+// How long a mole lingers before ducking back; shrinks over the round.
+export function moleLifetime(elapsedMs: number): number {
+  return Math.round(lerp(LIFETIME_START_MS, LIFETIME_END_MS, progress(elapsedMs)));
+}
+
+// Points a single hit is worth at the given streak length (the streak counts
+// the hit being scored). Ramps one step every COMBO_STEP hits, capped.
+export function multiplier(streak: number): number {
+  if (streak <= 0) return 1;
+  return Math.min(MAX_MULTIPLIER, 1 + Math.floor((streak - 1) / COMBO_STEP));
+}
+
+// Pick a random empty hole; returns -1 when every hole is already occupied.
+export function pickHole(
+  occupied: readonly boolean[],
+  rand: () => number = Math.random,
+): number {
+  const free: number[] = [];
+  for (let i = 0; i < occupied.length; i++) {
+    if (!occupied[i]) free.push(i);
+  }
+  if (free.length === 0) return -1;
+  return free[Math.floor(rand() * free.length)];
+}

--- a/src/app/playgrounds/whack-a-mole/_lib/useHighScore.ts
+++ b/src/app/playgrounds/whack-a-mole/_lib/useHighScore.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const KEY = "whack-a-mole-high";
+
+// Same-tab change notifications: the native `storage` event only fires in
+// other tabs, so we keep our own listener set and emit on write.
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+// getSnapshot must return a stable reference between renders, so we memoise
+// the parsed number against the raw string it came from.
+let cache: { raw: string | null; value: number } = { raw: null, value: 0 };
+
+function getSnapshot(): number {
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(KEY);
+  } catch {
+    raw = null;
+  }
+  if (cache.raw !== raw) {
+    const parsed = raw ? Number.parseInt(raw, 10) : 0;
+    cache = { raw, value: Number.isFinite(parsed) ? parsed : 0 };
+  }
+  return cache.value;
+}
+
+export function useHighScore() {
+  const high = useSyncExternalStore(subscribe, getSnapshot, () => 0);
+
+  // Record `score` only when it beats the stored best. Returns true when a
+  // new record was written.
+  const saveIfHigh = useCallback((score: number): boolean => {
+    if (score <= getSnapshot()) return false;
+    try {
+      window.localStorage.setItem(KEY, String(score));
+    } catch {
+      // Storage unavailable (private mode etc.); keep playing regardless.
+    }
+    listeners.forEach((l) => l());
+    return true;
+  }, []);
+
+  return { high, saveIfHigh };
+}

--- a/src/app/playgrounds/whack-a-mole/opengraph-image.tsx
+++ b/src/app/playgrounds/whack-a-mole/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Whack-a-Mole";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Whack-a-Mole",
+  "Bonk the moles before they duck away. They get faster and faster.",
+);

--- a/src/app/playgrounds/whack-a-mole/page.tsx
+++ b/src/app/playgrounds/whack-a-mole/page.tsx
@@ -1,0 +1,17 @@
+import { WhackAMole } from "./_components/WhackAMole";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Whack-a-Mole | Playground",
+  description:
+    "Bonk the moles before they duck away. They get faster and faster, then it scores you. Beat your high score.",
+  openGraph: {
+    title: "Whack-a-Mole",
+    description:
+      "Bonk the moles before they duck away. They get faster and faster, then it scores you. Beat your high score.",
+  },
+};
+
+export default function WhackAMolePage() {
+  return <WhackAMole />;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,6 +39,29 @@
   100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 
+/* --- Whack-a-Mole --- */
+
+/* A whacked mole squashing down and dropping back into its hole. */
+@keyframes mole-bonk {
+  0% { transform: translateY(0) scaleY(1); }
+  30% { transform: translateY(8%) scale(1.18, 0.72); }
+  100% { transform: translateY(135%) scale(0.85); }
+}
+
+/* The points earned on a hit, drifting up and fading. */
+@keyframes score-float {
+  0% { opacity: 0; transform: translateY(8px) scale(0.7); }
+  25% { opacity: 1; transform: translateY(-6px) scale(1.15); }
+  100% { opacity: 0; transform: translateY(-44px) scale(1); }
+}
+
+/* The streak badge giving a kick each time it climbs. */
+@keyframes combo-pop {
+  0% { transform: scale(0.6) rotate(-6deg); }
+  60% { transform: scale(1.18) rotate(4deg); }
+  100% { transform: scale(1) rotate(-3deg); }
+}
+
 /* --- Lottery: "The Midnight Draw" --- */
 
 @utility font-marquee {


### PR DESCRIPTION
## What

A new Whack-a-Mole playground, registered under Games on the homepage.

- 3x3 grid of dirt holes set in a grass field; moles pop up at random and you bonk them before they duck back.
- Difficulty ramps over a 30-second round: the spawn gap tightens (800ms → 300ms) and moles linger for less time (1050ms → 500ms), so it gets faster the longer you last.
- Combo multiplier (up to 5x) builds on consecutive hits and resets on a miss, with a floating "+N" popup, a live streak badge, and a hit flash.
- Synthesized Web Audio "thock" on hit / "thud" on miss, with a mute toggle. No audio assets or new dependencies.
- End screen reports points, accuracy and best streak. High score persists in `localStorage` and shows in the stat bar.
- "Play again" is locked for ~900ms after time runs out, so end-of-round mashing can't restart by accident.
- Matches the neo-brutalist house style; includes a homepage preview card and an OG image.

## Why

Adds another quick, self-contained game to the playground collection.

## Risk / testing

Low risk: fully self-contained, no shared code touched beyond the homepage registry and CSS keyframes.

- `pnpm test` on the game logic (ramp, multiplier, hole selection): 11/11 pass
- `pnpm exec tsc --noEmit`: clean
- `pnpm lint`: clean for the new files
- `pnpm build`: succeeds, route and OG image emitted

Not verified by CI (no browser tooling in this environment): the actual pop/whack feel, audio, and combo juice. Worth an eyeball via `pnpm dev` at `/playgrounds/whack-a-mole`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)