### PR TITLE
feat: add a Neuroevolution playground where cars learn to race

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,7 @@ import { MemoryPreview } from "./playgrounds/memory/Preview";
 import { SimonPreview } from "./playgrounds/simon/Preview";
 import { ChickenCrossingPreview } from "./playgrounds/chicken-crossing/Preview";
 import { WhackAMolePreview } from "./playgrounds/whack-a-mole/Preview";
+import { NeuroevolutionPreview } from "./playgrounds/neuroevolution/Preview";
 
 type Category =
   | "Games"
@@ -183,6 +184,15 @@ const playgrounds = [
     description: "Play Connect 4 against an AlphaZero-style AI trained via self-play.",
     href: "/playgrounds/connect-four",
     preview: ConnectFourPreview,
+    category: "AI",
+  },
+  {
+    id: "neuroevolution",
+    title: "Neuroevolution",
+    description:
+      "A population of cars grow neural-net brains via a genetic algorithm, learning to drive a track live. No training data, just survival of the fittest.",
+    href: "/playgrounds/neuroevolution",
+    preview: NeuroevolutionPreview,
     category: "AI",
   },
   {

--- a/src/app/playgrounds/neuroevolution/Preview.tsx
+++ b/src/app/playgrounds/neuroevolution/Preview.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRef } from "react";
+import { useIntersectionObserver } from "../../_hooks";
+
+// An elliptical track with a handful of cars looping around via SVG motion.
+// Cars only animate while the card is on screen.
+const ELLIPSE =
+  "M 22,70 a 78,48 0 1,0 156,0 a 78,48 0 1,0 -156,0";
+
+const CARS = [
+  { color: "#38bdf8", begin: "0s" },
+  { color: "#38bdf8", begin: "-1.6s" },
+  { color: "#38bdf8", begin: "-3.1s" },
+  { color: "#f7c948", begin: "-4.4s" },
+];
+
+export function NeuroevolutionPreview() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver(containerRef);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-full w-full items-center justify-center bg-[#0d0d0d]"
+    >
+      <svg viewBox="0 0 200 140" className="h-full w-full">
+        {/* road band */}
+        <path d={ELLIPSE} fill="none" stroke="#191920" strokeWidth={20} />
+        <path d={ELLIPSE} fill="none" stroke="#4b5563" strokeWidth={1.5} />
+        {/* start gate */}
+        <line x1="22" y1="60" x2="22" y2="80" stroke="#34d399" strokeWidth={2.5} />
+
+        {CARS.map((car, i) => (
+          <g key={i}>
+            <polygon points="0,-3 7,0 0,3" fill={car.color} />
+            {isVisible && (
+              <animateMotion
+                dur="5s"
+                begin={car.begin}
+                repeatCount="indefinite"
+                rotate="auto"
+                path={ELLIPSE}
+              />
+            )}
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
@@ -2,13 +2,21 @@
 
 import { useMemo } from "react";
 import type { Network } from "../../_lib/nn";
+import { SENSOR_ANGLES } from "../../_lib/car";
 
 const W = 240;
 const H = 200;
 const PAD_X = 34;
 const PAD_Y = 18;
 
-const INPUT_LABELS = ["L60", "L30", "fwd", "R30", "R60", "spd"];
+// Labels track the sensor angles (L/R + degrees), then the speed input.
+const INPUT_LABELS = [
+  ...SENSOR_ANGLES.map((a) => {
+    const d = Math.round((a * 180) / Math.PI);
+    return d === 0 ? "fwd" : d < 0 ? `L${-d}` : `R${d}`;
+  }),
+  "spd",
+];
 const OUTPUT_LABELS = ["steer", "gas"];
 
 // Draws the leader's brain: nodes in columns, edges tinted by weight sign and

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
@@ -33,20 +33,20 @@ export function NetworkView({ net }: { net: Network | null }) {
           y1={e.y1}
           x2={e.x2}
           y2={e.y2}
-          stroke={e.positive ? "#38bdf8" : "#ef3d2f"}
+          stroke={e.positive ? "#45c8d8" : "#ff5140"}
           strokeWidth={e.width}
           strokeOpacity={e.opacity}
         />
       ))}
       {layout.nodes.map((n, i) => (
         <g key={i}>
-          <circle cx={n.x} cy={n.y} r={5} fill="#0d0d0d" stroke="#fffef5" strokeWidth={1.5} />
+          <circle cx={n.x} cy={n.y} r={4.5} fill="#0d1016" stroke="rgba(233,239,243,0.55)" strokeWidth={1.25} />
           {n.label && (
             <text
               x={n.labelRight ? n.x + 9 : n.x - 9}
               y={n.y + 3}
               textAnchor={n.labelRight ? "start" : "end"}
-              className="fill-white/45 font-mono"
+              className="fill-white/45 font-readout"
               fontSize={7}
             >
               {n.label}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Network } from "../../_lib/nn";
+
+const W = 240;
+const H = 200;
+const PAD_X = 34;
+const PAD_Y = 18;
+
+const INPUT_LABELS = ["L60", "L30", "fwd", "R30", "R60", "spd"];
+const OUTPUT_LABELS = ["steer", "gas"];
+
+// Draws the leader's brain: nodes in columns, edges tinted by weight sign and
+// weighted by magnitude. Positive = cyan, negative = red.
+export function NetworkView({ net }: { net: Network | null }) {
+  const layout = useMemo(() => (net ? buildLayout(net) : null), [net]);
+
+  if (!layout) {
+    return (
+      <div className="flex h-[200px] items-center justify-center font-mono text-[11px] uppercase tracking-widest text-white/30">
+        no leader yet
+      </div>
+    );
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="h-auto w-full" role="img" aria-label="Leader neural network">
+      {layout.edges.map((e, i) => (
+        <line
+          key={i}
+          x1={e.x1}
+          y1={e.y1}
+          x2={e.x2}
+          y2={e.y2}
+          stroke={e.positive ? "#38bdf8" : "#ef3d2f"}
+          strokeWidth={e.width}
+          strokeOpacity={e.opacity}
+        />
+      ))}
+      {layout.nodes.map((n, i) => (
+        <g key={i}>
+          <circle cx={n.x} cy={n.y} r={5} fill="#0d0d0d" stroke="#fffef5" strokeWidth={1.5} />
+          {n.label && (
+            <text
+              x={n.labelRight ? n.x + 9 : n.x - 9}
+              y={n.y + 3}
+              textAnchor={n.labelRight ? "start" : "end"}
+              className="fill-white/45 font-mono"
+              fontSize={7}
+            >
+              {n.label}
+            </text>
+          )}
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+interface Node {
+  x: number;
+  y: number;
+  label?: string;
+  labelRight?: boolean;
+}
+interface Edge {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  positive: boolean;
+  width: number;
+  opacity: number;
+}
+
+function buildLayout(net: Network) {
+  // Column sizes: input layer plus each layer's output.
+  const sizes = [net.layers[0].inSize, ...net.layers.map((l) => l.outSize)];
+  const cols = sizes.length;
+  const colX = (c: number) => PAD_X + (c / (cols - 1)) * (W - 2 * PAD_X);
+  const nodeY = (count: number, i: number) =>
+    count === 1 ? H / 2 : PAD_Y + (i / (count - 1)) * (H - 2 * PAD_Y);
+
+  const nodes: Node[] = [];
+  const positions: { x: number; y: number }[][] = [];
+  sizes.forEach((count, c) => {
+    const col: { x: number; y: number }[] = [];
+    for (let i = 0; i < count; i++) {
+      const x = colX(c);
+      const y = nodeY(count, i);
+      col.push({ x, y });
+      const isInput = c === 0;
+      const isOutput = c === cols - 1;
+      nodes.push({
+        x,
+        y,
+        label: isInput ? INPUT_LABELS[i] : isOutput ? OUTPUT_LABELS[i] : undefined,
+        labelRight: isOutput,
+      });
+    }
+    positions.push(col);
+  });
+
+  // Normalise edge width against the largest absolute weight in the net.
+  let maxW = 0;
+  for (const l of net.layers) for (const w of l.w) maxW = Math.max(maxW, Math.abs(w));
+  maxW = maxW || 1;
+
+  const edges: Edge[] = [];
+  net.layers.forEach((layer, li) => {
+    const from = positions[li];
+    const to = positions[li + 1];
+    for (let j = 0; j < layer.outSize; j++) {
+      for (let i = 0; i < layer.inSize; i++) {
+        const w = layer.w[j * layer.inSize + i];
+        const mag = Math.abs(w) / maxW;
+        edges.push({
+          x1: from[i].x,
+          y1: from[i].y,
+          x2: to[j].x,
+          y2: to[j].y,
+          positive: w >= 0,
+          width: 0.3 + mag * 2,
+          opacity: 0.08 + mag * 0.6,
+        });
+      }
+    }
+  });
+
+  return { nodes, edges };
+}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { mulberry32 } from "../../_lib/geometry";
+import type { Network } from "../../_lib/nn";
+import { clearWorld, loadWorld, saveWorld } from "../../_lib/persistence";
+import { createCar } from "../../_lib/car";
+import { buildTrack } from "../../_lib/track";
+import { drawWorld } from "../../_lib/render";
+import { LAPS_TO_FINISH } from "../../_lib/car";
+import { idealRunTicks } from "../../_lib/optimum";
+import {
+  DEFAULT_CONFIG,
+  activeCount,
+  bestFinishTicks,
+  createWorld,
+  leader,
+  stepWorld,
+  type SimConfig,
+  type World,
+} from "../../_lib/world";
+import { NetworkView } from "./NetworkView";
+import { Sparkline } from "./Sparkline";
+
+const VIEWPORT = { width: 900, height: 600 };
+const SPEEDS = [1, 2, 4, 8];
+// Flush HUD state ~10x/second rather than every frame.
+const HUD_EVERY = 6;
+// Nominal ticks per second, for turning finish-tick counts into a time.
+const TICKS_PER_SEC = 60;
+
+interface Stats {
+  generation: number;
+  active: number;
+  pop: number;
+  genTicks: number;
+  bestTicks: number;
+  idealTicks: number;
+  runTimes: number[];
+  leaderNet: Network | null;
+}
+
+const EMPTY_STATS: Stats = {
+  generation: 1,
+  active: 0,
+  pop: DEFAULT_CONFIG.populationSize,
+  genTicks: 0,
+  bestTicks: 0,
+  idealTicks: 0,
+  runTimes: [],
+  leaderNet: null,
+};
+
+function formatTime(ticks: number): string {
+  if (ticks <= 0) return "—";
+  return `${(ticks / TICKS_PER_SEC).toFixed(1)}s`;
+}
+
+export function Neuroevolution() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const worldRef = useRef<World | null>(null);
+  const randRef = useRef<() => number>(mulberry32(1));
+  const seedRef = useRef(1);
+  const configRef = useRef<SimConfig>({ ...DEFAULT_CONFIG });
+
+  const pausedRef = useRef(false);
+  const speedRef = useRef(2);
+  const sensorsRef = useRef(true);
+  const savedGenRef = useRef(0);
+
+  const [stats, setStats] = useState<Stats>(EMPTY_STATS);
+  const [paused, setPaused] = useState(false);
+  const [speed, setSpeed] = useState(2);
+  const [sensors, setSensors] = useState(true);
+  const [mutationRate, setMutationRate] = useState(DEFAULT_CONFIG.mutationRate);
+  const [varyTrack, setVaryTrack] = useState(DEFAULT_CONFIG.varyTrack);
+
+  const flush = useCallback(() => {
+    const w = worldRef.current;
+    if (!w) return;
+    const lead = leader(w);
+    const genTicks = bestFinishTicks(w);
+    const bestTicks =
+      genTicks > 0 && (w.bestTicks === 0 || genTicks < w.bestTicks)
+        ? genTicks
+        : w.bestTicks;
+    setStats({
+      generation: w.generation,
+      active: activeCount(w),
+      pop: w.cars.length,
+      genTicks,
+      bestTicks,
+      idealTicks: idealRunTicks(w.track),
+      runTimes: w.timeHistory.map((t) => t / 60),
+      leaderNet: lead ? lead.net : null,
+    });
+  }, []);
+
+  // Start a new track. keepBrains carries the current population over (watch
+  // them handle, then re-adapt to, a fresh course); otherwise a random one.
+  const startWorld = useCallback(
+    (keepBrains: boolean) => {
+      clearWorld();
+      seedRef.current += 1;
+      randRef.current = mulberry32(seedRef.current);
+      const prev = worldRef.current;
+      let world: World;
+      if (keepBrains && prev) {
+        const track = buildTrack(VIEWPORT, randRef.current);
+        world = {
+          track,
+          cars: prev.cars.map((c) => createCar(c.net, track)),
+          generation: prev.generation,
+          step: 0,
+          bestEver: 0,
+          bestTicks: 0,
+          history: [],
+          timeHistory: [],
+        };
+      } else {
+        world = createWorld(configRef.current, VIEWPORT, randRef.current);
+      }
+      worldRef.current = world;
+      savedGenRef.current = world.generation;
+      saveWorld(world);
+      flush();
+    },
+    [flush],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    randRef.current = mulberry32(seedRef.current);
+
+    // Resume a saved run if there is one, else start fresh.
+    const saved = loadWorld();
+    if (saved) {
+      worldRef.current = {
+        track: saved.track,
+        cars: saved.nets.map((net) => createCar(net, saved.track)),
+        generation: saved.generation,
+        step: 0,
+        bestEver: saved.bestEver,
+        bestTicks: saved.bestTicks,
+        history: saved.history,
+        timeHistory: saved.timeHistory ?? [],
+      };
+    } else {
+      worldRef.current = createWorld(configRef.current, VIEWPORT, randRef.current);
+    }
+    savedGenRef.current = worldRef.current.generation;
+    flush();
+
+    let animId = 0;
+    let frame = 0;
+
+    const loop = () => {
+      const w = worldRef.current;
+      if (w) {
+        if (!pausedRef.current) {
+          for (let s = 0; s < speedRef.current; s++) {
+            stepWorld(w, configRef.current, randRef.current);
+          }
+        }
+        drawWorld(ctx, w, sensorsRef.current);
+        // Persist once per generation so a refresh resumes where it left off.
+        if (w.generation !== savedGenRef.current) {
+          savedGenRef.current = w.generation;
+          saveWorld(w);
+        }
+        if (frame % HUD_EVERY === 0) flush();
+      }
+      frame++;
+      animId = requestAnimationFrame(loop);
+    };
+    animId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animId);
+  }, [flush]);
+
+  const togglePause = () => {
+    pausedRef.current = !pausedRef.current;
+    setPaused(pausedRef.current);
+  };
+  const pickSpeed = (s: number) => {
+    speedRef.current = s;
+    setSpeed(s);
+  };
+  const toggleSensors = () => {
+    sensorsRef.current = !sensorsRef.current;
+    setSensors(sensorsRef.current);
+  };
+  const changeMutation = (v: number) => {
+    configRef.current = { ...configRef.current, mutationRate: v };
+    setMutationRate(v);
+  };
+  const toggleVary = () => {
+    const next = !varyTrack;
+    configRef.current = { ...configRef.current, varyTrack: next };
+    setVaryTrack(next);
+  };
+
+  return (
+    <div className="min-h-full bg-[#0d0d0d] text-[#fffef5]">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:py-10">
+        {/* Header */}
+        <header className="mb-6">
+          <div className="mb-4 h-1 bg-[#f7c948]" />
+          <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-white/40">
+            genetic algorithm · no training data
+          </p>
+          <h1 className="font-roboto-slab text-[clamp(2.5rem,8vw,4.5rem)] font-black leading-[0.85] tracking-tight">
+            Neuroevolution
+          </h1>
+          <p className="mt-3 max-w-2xl font-mono text-sm leading-relaxed text-white/50">
+            Every car is steered by its own little neural network, racing to
+            finish {LAPS_TO_FINISH} laps as fast as it can. The quickest breed
+            the next generation, with mutations. Nobody tells them how to drive;
+            the track does. Watch the lap times keep dropping.
+          </p>
+        </header>
+
+        <div className="grid gap-4 lg:grid-cols-[1.9fr_1fr]">
+          {/* Canvas */}
+          <div className="overflow-hidden rounded-lg border-[3px] border-white/15">
+            <canvas
+              ref={canvasRef}
+              width={VIEWPORT.width}
+              height={VIEWPORT.height}
+              className="block h-auto w-full"
+            />
+          </div>
+
+          {/* Side panel */}
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/15 bg-white/15">
+              <Stat label="Generation" value={String(stats.generation)} />
+              <Stat label="Driving" value={`${stats.active} / ${stats.pop}`} />
+              <Stat label="This gen" value={formatTime(stats.genTicks)} />
+              <Stat
+                label="Fastest run"
+                value={formatTime(stats.bestTicks)}
+                sub={`${LAPS_TO_FINISH} laps`}
+              />
+            </div>
+
+            {/* Physics-limit target for this exact track. */}
+            <div className="flex items-center justify-between rounded-lg border border-white/15 bg-white/[0.03] px-3 py-2">
+              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+                Track optimum
+              </span>
+              <span
+                className="font-roboto-slab text-lg font-black tabular-nums text-[#34d399]"
+                title="Estimated fastest possible run at the car's physical limits on this track"
+              >
+                ≈ {formatTime(stats.idealTicks)}
+              </span>
+            </div>
+
+            <Panel title="Best run time / generation (green = optimum)">
+              <Sparkline data={stats.runTimes} optimum={stats.idealTicks / 60} />
+            </Panel>
+
+            <Panel title="Leader's brain">
+              <NetworkView net={stats.leaderNet} />
+              <div className="mt-2 flex items-center justify-center gap-4 font-mono text-[9px] uppercase tracking-widest text-white/40">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2 w-3" style={{ background: "#38bdf8" }} />
+                  excite
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2 w-3" style={{ background: "#ef3d2f" }} />
+                  inhibit
+                </span>
+              </div>
+            </Panel>
+          </div>
+        </div>
+
+        {/* Controls */}
+        <div className="mt-4 flex flex-wrap items-center gap-3 rounded-lg border border-white/15 bg-white/[0.03] p-3">
+          <button
+            type="button"
+            onClick={togglePause}
+            className="rounded-md border-[3px] border-[#f7c948] bg-[#f7c948] px-4 py-2 font-mono text-xs font-bold uppercase tracking-widest text-black transition-transform hover:-translate-y-0.5"
+          >
+            {paused ? "Play" : "Pause"}
+          </button>
+
+          <div className="flex overflow-hidden rounded-md border border-white/20">
+            {SPEEDS.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => pickSpeed(s)}
+                className={`px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
+                  speed === s ? "bg-white/90 text-black" : "text-white/70 hover:bg-white/10"
+                }`}
+              >
+                {s}×
+              </button>
+            ))}
+          </div>
+
+          <label className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-widest text-white/60">
+            Mutation
+            <input
+              type="range"
+              min={0}
+              max={0.5}
+              step={0.01}
+              value={mutationRate}
+              onChange={(e) => changeMutation(Number(e.target.value))}
+              className="w-28 accent-[#f7c948]"
+            />
+            <span className="w-8 tabular-nums text-white/80">
+              {mutationRate.toFixed(2)}
+            </span>
+          </label>
+
+          <button
+            type="button"
+            onClick={toggleSensors}
+            aria-pressed={sensors}
+            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
+              sensors
+                ? "border-white/40 bg-white/10 text-white"
+                : "border-white/20 text-white/50 hover:bg-white/5"
+            }`}
+          >
+            Sensors
+          </button>
+
+          <button
+            type="button"
+            onClick={toggleVary}
+            aria-pressed={varyTrack}
+            title="Generate a fresh track every generation, so cars learn to drive in general instead of memorising one track"
+            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
+              varyTrack
+                ? "border-white/40 bg-white/10 text-white"
+                : "border-white/20 text-white/50 hover:bg-white/5"
+            }`}
+          >
+            Vary track
+          </button>
+
+          <div className="ml-auto flex gap-2">
+            <button
+              type="button"
+              onClick={() => startWorld(true)}
+              title="Keep the current brains, drop them on a brand-new track"
+              className="rounded-md border border-white/20 px-4 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
+            >
+              New track
+            </button>
+            <button
+              type="button"
+              onClick={() => startWorld(false)}
+              title="New track and a fresh population of random brains"
+              className="rounded-md border border-[#ef3d2f]/60 px-4 py-2 font-mono text-xs uppercase tracking-widest text-[#ef3d2f] transition-colors hover:bg-[#ef3d2f] hover:text-black"
+            >
+              Fresh start
+            </button>
+          </div>
+        </div>
+
+        <p className="mt-2 font-mono text-[10px] uppercase tracking-widest text-white/30">
+          auto-saves · refresh resumes · new track keeps the brains · fresh start wipes them
+          {varyTrack ? " · varying track each generation" : ""}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="bg-[#0d0d0d] px-3 py-3">
+      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+        {label}
+      </div>
+      <div className="font-roboto-slab text-2xl font-black leading-tight tabular-nums">
+        {value}
+      </div>
+      {sub && (
+        <div className="font-mono text-[10px] uppercase tracking-widest text-[#f7c948]/80">
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-white/15 bg-white/[0.03] p-3">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -10,6 +10,7 @@ import { drawWorld } from "../../_lib/render";
 import { idealRunTicks } from "../../_lib/optimum";
 import { populationFrom } from "../../_lib/genetic";
 import { parseBrain, serializeBrain } from "../../_lib/brainIO";
+import { display, mono } from "../../_lib/fonts";
 import {
   DEFAULT_CONFIG,
   activeCount,
@@ -63,9 +64,9 @@ const EMPTY_STATS: Stats = {
   soloBestTicks: 0,
 };
 
-function formatTime(ticks: number): string {
-  if (ticks <= 0) return "—";
-  return `${(ticks / TICKS_PER_SEC).toFixed(1)}s`;
+// Seconds string for a tick count ("—" when there's nothing yet).
+function secs(ticks: number): string {
+  return ticks > 0 ? (ticks / TICKS_PER_SEC).toFixed(1) : "—";
 }
 
 export function Neuroevolution() {
@@ -316,7 +317,7 @@ export function Neuroevolution() {
     a.download = `neuro-brain-gen${w?.generation ?? 0}.json`;
     a.click();
     URL.revokeObjectURL(url);
-    setIoMsg("Brain downloaded");
+    setIoMsg("Brain exported");
   };
 
   const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -366,91 +367,191 @@ export function Neuroevolution() {
     setIoMsg("Seeded a fresh population from the champion");
   };
 
-  return (
-    <div className="min-h-full bg-[#0d0d0d] text-[#fffef5]">
-      <div className="mx-auto max-w-6xl px-4 py-8 sm:py-10">
-        {/* Header */}
-        <header className="mb-6">
-          <div className="mb-4 h-1 bg-[#f7c948]" />
-          <p className="mb-1 font-mono text-[11px] uppercase tracking-[0.3em] text-white/40">
-            genetic algorithm · no training data
-          </p>
-          <h1 className="font-roboto-slab text-[clamp(2.5rem,8vw,4.5rem)] font-black leading-[0.85] tracking-tight">
-            Neuroevolution
-          </h1>
-          <p className="mt-3 max-w-2xl font-mono text-sm leading-relaxed text-white/50">
-            Every car is steered by its own little neural network, racing to
-            finish {LAPS_TO_FINISH} laps as fast as it can. The quickest breed
-            the next generation, with mutations. Nobody tells them how to drive;
-            the track does. Watch the lap times keep dropping.
-          </p>
-        </header>
+  const solo = mode === "solo";
+  const shownBest = solo ? stats.soloBestTicks : stats.bestTicks;
+  const deltaS =
+    shownBest > 0 && stats.idealTicks > 0
+      ? (shownBest - stats.idealTicks) / TICKS_PER_SEC
+      : null;
 
-        <div className="grid gap-4 lg:grid-cols-[1.9fr_1fr]">
-          {/* Canvas */}
-          <div className="overflow-hidden rounded-lg border-[3px] border-white/15">
-            <canvas
-              ref={canvasRef}
-              width={VIEWPORT.width}
-              height={VIEWPORT.height}
-              className="block h-auto w-full"
+  return (
+    <div
+      className={`${display.variable} ${mono.variable} neuro-console h-full overflow-y-auto`}
+      style={{
+        backgroundColor: "var(--ink)",
+        color: "var(--text)",
+        backgroundImage:
+          "linear-gradient(rgba(150,180,205,0.045) 1px, transparent 1px), linear-gradient(90deg, rgba(150,180,205,0.045) 1px, transparent 1px), radial-gradient(130% 90% at 50% -10%, rgba(69,200,216,0.07), transparent 55%)",
+        backgroundSize: "46px 46px, 46px 46px, 100% 100%",
+      }}
+    >
+      <div className="relative mx-auto max-w-6xl px-4 py-6 sm:py-8">
+        {/* One-time boot scanline sweep */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
+          <div
+            className="h-24 w-full"
+            style={{
+              background:
+                "linear-gradient(to bottom, transparent, rgba(69,200,216,0.10), transparent)",
+              animation: "neuro-sweep 1.1s ease-out 0.1s both",
+            }}
+          />
+        </div>
+
+        {/* Header */}
+        <header
+          className="neuro-boot relative z-10 mb-5 flex flex-wrap items-end justify-between gap-4 border-b border-[var(--line)] pb-3"
+          style={{ animationDelay: "0ms" }}
+        >
+          <div>
+            <div className="mb-2 flex items-center gap-2 font-readout text-[10px] uppercase tracking-[0.35em] text-[var(--muted)]">
+              <LED on={!paused} color="var(--mint)" />
+              Genetic drive model
+              <span className="text-[var(--line-2)]">·</span>
+              <span className="text-[var(--muted)]">no training data</span>
+            </div>
+            <h1 className="font-telemetry text-[clamp(2rem,6vw,3.4rem)] font-bold uppercase leading-[0.85] tracking-tight">
+              Neuro<span className="text-[var(--cyan)]">evolution</span>
+            </h1>
+          </div>
+          <div className="flex items-stretch gap-4">
+            <HeaderStat label="Gen" value={solo ? "—" : String(stats.generation)} />
+            <div className="w-px bg-[var(--line)]" />
+            <HeaderStat
+              label="Mode"
+              value={solo ? "Solo" : "Evolve"}
+              accent={solo ? "var(--amber)" : "var(--cyan)"}
             />
           </div>
+        </header>
 
-          {/* Side panel */}
+        <p className="neuro-boot relative z-10 mb-5 max-w-2xl font-readout text-[11px] leading-relaxed text-[var(--muted)]" style={{ animationDelay: "40ms" }}>
+          Each car drives with its own neural network, racing to finish{" "}
+          {LAPS_TO_FINISH} laps flat out. The fastest breed the next generation,
+          with mutations. Nobody teaches them the line — the track does.
+        </p>
+
+        <div className="relative z-10 grid gap-4 lg:grid-cols-[1.9fr_1fr]">
+          {/* Track viewport */}
+          <Panel
+            index="01"
+            title={solo ? "Solo run" : "Track"}
+            right={<Tag on>Live</Tag>}
+            bodyClass="p-0"
+            className="neuro-boot"
+            style={{ animationDelay: "80ms" }}
+          >
+            <div className="relative">
+              <canvas
+                ref={canvasRef}
+                width={VIEWPORT.width}
+                height={VIEWPORT.height}
+                className="block h-auto w-full"
+              />
+              {/* CRT scanlines */}
+              <div
+                className="pointer-events-none absolute inset-0 opacity-40 mix-blend-overlay"
+                aria-hidden
+                style={{
+                  backgroundImage:
+                    "repeating-linear-gradient(0deg, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 3px)",
+                }}
+              />
+            </div>
+          </Panel>
+
+          {/* Side stack */}
           <div className="flex flex-col gap-4">
-            <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/15 bg-white/15">
-              {stats.mode === "solo" ? (
-                <>
-                  <Stat label="Mode" value="Solo" />
-                  <Stat label="Laps" value={`${stats.soloLaps} / ${LAPS_TO_FINISH}`} />
-                  <Stat label="This run" value={formatTime(stats.soloRunTicks)} />
-                  <Stat
-                    label="Best run"
-                    value={formatTime(stats.soloBestTicks)}
-                    sub={`${LAPS_TO_FINISH} laps`}
-                  />
-                </>
-              ) : (
-                <>
-                  <Stat label="Generation" value={String(stats.generation)} />
-                  <Stat label="Driving" value={`${stats.active} / ${stats.pop}`} />
-                  <Stat label="This gen" value={formatTime(stats.genTicks)} />
-                  <Stat
-                    label="Fastest run"
-                    value={formatTime(stats.bestTicks)}
-                    sub={`${LAPS_TO_FINISH} laps`}
-                  />
-                </>
-              )}
-            </div>
+            <Panel
+              index="02"
+              title="Telemetry"
+              className="neuro-boot"
+              bodyClass="p-0"
+              style={{ animationDelay: "140ms" }}
+            >
+              <div className="grid grid-cols-2">
+                {solo ? (
+                  <>
+                    <Readout label="Mode" value="Solo" accent="var(--amber)" />
+                    <Readout
+                      label="Laps"
+                      value={`${stats.soloLaps}/${LAPS_TO_FINISH}`}
+                    />
+                    <Readout
+                      label="This run"
+                      value={secs(stats.soloRunTicks)}
+                      unit={stats.soloRunTicks > 0 ? "s" : ""}
+                    />
+                    <Readout
+                      label="Best run"
+                      value={secs(stats.soloBestTicks)}
+                      unit={stats.soloBestTicks > 0 ? "s" : ""}
+                      accent="var(--amber)"
+                      live={stats.soloBestTicks > 0}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <Readout label="Generation" value={String(stats.generation)} />
+                    <Readout label="Driving" value={`${stats.active}/${stats.pop}`} />
+                    <Readout
+                      label="This gen"
+                      value={secs(stats.genTicks)}
+                      unit={stats.genTicks > 0 ? "s" : ""}
+                    />
+                    <Readout
+                      label="Fastest"
+                      value={secs(stats.bestTicks)}
+                      unit={stats.bestTicks > 0 ? "s" : ""}
+                      accent="var(--amber)"
+                      live={stats.bestTicks > 0}
+                    />
+                  </>
+                )}
+              </div>
+              {/* Target + delta */}
+              <div className="flex items-center justify-between border-t border-[var(--line)] px-3 py-2.5">
+                <span className="font-readout text-[9px] uppercase tracking-[0.25em] text-[var(--muted)]">
+                  Track optimum
+                </span>
+                <div className="flex items-baseline gap-3">
+                  <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--mint)]">
+                    ≈ {secs(stats.idealTicks)}
+                    <span className="ml-0.5 text-[10px] text-[var(--muted)]">s</span>
+                  </span>
+                  {deltaS !== null && <DeltaChip delta={deltaS} />}
+                </div>
+              </div>
+            </Panel>
 
-            {/* Physics-limit target for this exact track. */}
-            <div className="flex items-center justify-between rounded-lg border border-white/15 bg-white/[0.03] px-3 py-2">
-              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
-                Track optimum
-              </span>
-              <span
-                className="font-roboto-slab text-lg font-black tabular-nums text-[#34d399]"
-                title="Estimated fastest possible run at the car's physical limits on this track"
-              >
-                ≈ {formatTime(stats.idealTicks)}
-              </span>
-            </div>
-
-            <Panel title="Best run time / generation (green = optimum)">
+            <Panel
+              index="03"
+              title="Lap time / generation"
+              right={
+                <span className="font-readout text-[9px] uppercase tracking-[0.2em] text-[var(--mint)]">
+                  — optimum
+                </span>
+              }
+              className="neuro-boot"
+              style={{ animationDelay: "200ms" }}
+            >
               <Sparkline data={stats.runTimes} optimum={stats.idealTicks / 60} />
             </Panel>
 
-            <Panel title="Leader's brain">
+            <Panel
+              index="04"
+              title="Leader schematic"
+              className="neuro-boot"
+              style={{ animationDelay: "260ms" }}
+            >
               <NetworkView net={stats.leaderNet} />
-              <div className="mt-2 flex items-center justify-center gap-4 font-mono text-[9px] uppercase tracking-widest text-white/40">
-                <span className="flex items-center gap-1">
-                  <span className="inline-block h-2 w-3" style={{ background: "#38bdf8" }} />
+              <div className="mt-2 flex items-center justify-center gap-4 font-readout text-[9px] uppercase tracking-[0.2em] text-[var(--muted)]">
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-2 w-3 rounded-[1px] bg-[var(--cyan)]" />
                   excite
                 </span>
-                <span className="flex items-center gap-1">
-                  <span className="inline-block h-2 w-3" style={{ background: "#ef3d2f" }} />
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-2 w-3 rounded-[1px] bg-[var(--red)]" />
                   inhibit
                 </span>
               </div>
@@ -458,192 +559,383 @@ export function Neuroevolution() {
           </div>
         </div>
 
-        {/* Controls */}
-        <div className="mt-4 flex flex-wrap items-center gap-3 rounded-lg border border-white/15 bg-white/[0.03] p-3">
-          <button
-            type="button"
-            onClick={togglePause}
-            className="rounded-md border-[3px] border-[#f7c948] bg-[#f7c948] px-4 py-2 font-mono text-xs font-bold uppercase tracking-widest text-black transition-transform hover:-translate-y-0.5"
-          >
-            {paused ? "Play" : "Pause"}
-          </button>
+        {/* Control deck */}
+        <Panel
+          index="05"
+          title="Control deck"
+          className="neuro-boot relative z-10 mt-4"
+          style={{ animationDelay: "320ms" }}
+        >
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+            {/* Transport */}
+            <button
+              type="button"
+              onClick={togglePause}
+              aria-label={paused ? "Play" : "Pause"}
+              className="flex h-10 w-10 items-center justify-center rounded-sm border border-[var(--amber)] bg-[var(--amber)] text-black transition hover:brightness-110"
+            >
+              {paused ? <PlayIcon /> : <PauseIcon />}
+            </button>
 
-          <div className="flex overflow-hidden rounded-md border border-white/20">
-            {SPEEDS.map((s) => (
-              <button
-                key={s}
-                type="button"
-                onClick={() => pickSpeed(s)}
-                className={`px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
-                  speed === s ? "bg-white/90 text-black" : "text-white/70 hover:bg-white/10"
-                }`}
-              >
-                {s}×
-              </button>
-            ))}
-          </div>
+            {/* Speed */}
+            <div className="flex items-center gap-2">
+              <FieldLabel>Speed</FieldLabel>
+              <div className="flex overflow-hidden rounded-sm border border-[var(--line-2)]">
+                {SPEEDS.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => pickSpeed(s)}
+                    className={`px-2.5 py-1.5 font-readout text-[11px] tabular-nums transition-colors ${
+                      speed === s
+                        ? "bg-[var(--cyan)]/20 text-[var(--cyan)]"
+                        : "text-[var(--muted)] hover:text-[var(--text)]"
+                    }`}
+                  >
+                    {s}×
+                  </button>
+                ))}
+              </div>
+            </div>
 
-          <label className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-widest text-white/60">
-            Mutation
-            <input
-              type="range"
-              min={0}
-              max={0.5}
-              step={0.01}
-              value={mutationRate}
-              onChange={(e) => changeMutation(Number(e.target.value))}
-              className="w-28 accent-[#f7c948]"
+            {/* Mutation */}
+            <div className="flex items-center gap-2">
+              <FieldLabel>Mutation</FieldLabel>
+              <input
+                type="range"
+                min={0}
+                max={0.5}
+                step={0.01}
+                value={mutationRate}
+                onChange={(e) => changeMutation(Number(e.target.value))}
+                className="neuro-range w-28"
+                style={{ ["--pct" as string]: `${(mutationRate / 0.5) * 100}%` }}
+              />
+              <span className="w-9 font-readout text-[11px] tabular-nums text-[var(--text)]">
+                {mutationRate.toFixed(2)}
+              </span>
+            </div>
+
+            <Switch on={sensors} onClick={toggleSensors} label="Sensors" />
+            <Switch
+              on={varyTrack}
+              onClick={toggleVary}
+              label="Vary track"
+              title="Fresh track every generation, so cars learn to drive in general instead of memorising one track"
             />
-            <span className="w-8 tabular-nums text-white/80">
-              {mutationRate.toFixed(2)}
-            </span>
-          </label>
 
-          <button
-            type="button"
-            onClick={toggleSensors}
-            aria-pressed={sensors}
-            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
-              sensors
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 text-white/50 hover:bg-white/5"
-            }`}
-          >
-            Sensors
-          </button>
-
-          <button
-            type="button"
-            onClick={toggleVary}
-            aria-pressed={varyTrack}
-            title="Generate a fresh track every generation, so cars learn to drive in general instead of memorising one track"
-            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
-              varyTrack
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 text-white/50 hover:bg-white/5"
-            }`}
-          >
-            Vary track
-          </button>
-
-          <div className="ml-auto flex gap-2">
-            <button
-              type="button"
-              onClick={() => startWorld(true)}
-              title="Keep the current brains, drop them on a brand-new track"
-              className="rounded-md border border-white/20 px-4 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
-            >
-              New track
-            </button>
-            <button
-              type="button"
-              onClick={() => startWorld(false)}
-              title="New track and a fresh population of random brains"
-              className="rounded-md border border-[#ef3d2f]/60 px-4 py-2 font-mono text-xs uppercase tracking-widest text-[#ef3d2f] transition-colors hover:bg-[#ef3d2f] hover:text-black"
-            >
-              Fresh start
-            </button>
+            <div className="ml-auto flex gap-2">
+              <DeckButton
+                onClick={() => startWorld(true)}
+                title="Keep the current brains, drop them on a brand-new track"
+              >
+                New track
+              </DeckButton>
+              <DeckButton
+                onClick={() => startWorld(false)}
+                title="New track and a fresh population of random brains"
+                tone="danger"
+              >
+                Fresh start
+              </DeckButton>
+            </div>
           </div>
-        </div>
 
-        <p className="mt-2 font-mono text-[10px] uppercase tracking-widest text-white/30">
-          auto-saves · refresh resumes · new track keeps the brains · fresh start wipes them
-          {varyTrack ? " · varying track each generation" : ""}
-        </p>
+          <p className="mt-3 border-t border-[var(--line)] pt-2.5 font-readout text-[9px] uppercase tracking-[0.2em] text-[var(--muted)]">
+            auto-saves · refresh resumes · new track keeps the brains · fresh start wipes them
+            {varyTrack ? " · varying track each generation" : ""}
+          </p>
+        </Panel>
 
-        {/* Champion: spotlight, save/load, or breed from the best brain */}
-        <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg border border-white/15 bg-white/[0.03] p-3">
-          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
-            Champion
-          </span>
-          <button
-            type="button"
-            onClick={toggleSolo}
-            aria-pressed={mode === "solo"}
-            title="Race just the best brain, on its own, looping"
-            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
-              mode === "solo"
-                ? "border-[#f7c948] bg-[#f7c948] text-black"
-                : "border-white/20 text-white/70 hover:bg-white/10"
-            }`}
-          >
-            {mode === "solo" ? "Back to evolving" : "Race solo"}
-          </button>
-          <button
-            type="button"
-            onClick={downloadBrain}
-            title="Save the best brain to a file"
-            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
-          >
-            Download
-          </button>
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            title="Load a brain from a file and race it solo"
-            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
-          >
-            Upload
-          </button>
-          <button
-            type="button"
-            onClick={breedFromChampion}
-            title="Start a fresh population evolved from this brain"
-            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
-          >
-            Breed from it
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="application/json,.json"
-            onChange={onFile}
-            className="hidden"
-          />
-          {ioMsg && (
-            <span className="ml-auto font-mono text-[10px] tracking-widest text-[#34d399]">
-              {ioMsg}
-            </span>
-          )}
-        </div>
+        {/* Garage / champion */}
+        <Panel
+          index="06"
+          title="Garage · champion"
+          right={
+            ioMsg ? (
+              <span className="font-readout text-[9px] uppercase tracking-[0.2em] text-[var(--mint)]">
+                {ioMsg}
+              </span>
+            ) : undefined
+          }
+          className="neuro-boot relative z-10 mt-4"
+          style={{ animationDelay: "380ms" }}
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <DeckButton
+              onClick={toggleSolo}
+              tone={solo ? "amber" : "line"}
+              title="Race just the best brain, on its own, looping"
+            >
+              {solo ? "Back to evolving" : "Race solo"}
+            </DeckButton>
+            <div className="mx-1 h-5 w-px bg-[var(--line)]" />
+            <DeckButton onClick={downloadBrain} title="Save the best brain to a file">
+              ↓ Export
+            </DeckButton>
+            <DeckButton
+              onClick={() => fileInputRef.current?.click()}
+              title="Load a brain from a file and race it solo"
+            >
+              ↑ Import
+            </DeckButton>
+            <DeckButton
+              onClick={breedFromChampion}
+              title="Start a fresh population evolved from this brain"
+            >
+              ⤳ Breed from it
+            </DeckButton>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              onChange={onFile}
+              className="hidden"
+            />
+          </div>
+        </Panel>
       </div>
     </div>
   );
 }
 
-function Stat({
+/* ---------- instrument sub-components ---------- */
+
+function Corners() {
+  const base = "pointer-events-none absolute h-1.5 w-1.5 border-[var(--line-2)]";
+  return (
+    <>
+      <span className={`${base} left-0 top-0 border-l border-t`} />
+      <span className={`${base} right-0 top-0 border-r border-t`} />
+      <span className={`${base} bottom-0 left-0 border-b border-l`} />
+      <span className={`${base} bottom-0 right-0 border-b border-r`} />
+    </>
+  );
+}
+
+function Panel({
+  index,
+  title,
+  right,
+  children,
+  className = "",
+  bodyClass = "p-3",
+  style,
+}: {
+  index?: string;
+  title?: string;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  bodyClass?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <section
+      className={`relative rounded-sm border border-[var(--line)] bg-[var(--panel)] ${className}`}
+      style={style}
+    >
+      <Corners />
+      {(title || right) && (
+        <div className="flex items-center justify-between gap-2 border-b border-[var(--line)] px-3 py-2">
+          <div className="flex items-center gap-2 font-readout text-[10px] uppercase tracking-[0.28em] text-[var(--muted)]">
+            {index && <span className="text-[var(--cyan)]/70">{index}</span>}
+            {title}
+          </div>
+          {right}
+        </div>
+      )}
+      <div className={bodyClass}>{children}</div>
+    </section>
+  );
+}
+
+function Readout({
   label,
   value,
-  sub,
+  unit,
+  accent = "var(--text)",
+  live = false,
 }: {
   label: string;
   value: string;
-  sub?: string;
+  unit?: string;
+  accent?: string;
+  live?: boolean;
 }) {
   return (
-    <div className="bg-[#0d0d0d] px-3 py-3">
-      <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+    <div className="border-b border-r border-[var(--line)] px-3 py-3 [&:nth-child(2n)]:border-r-0 [&:nth-last-child(-n+2)]:border-b-0">
+      <div className="mb-1.5 flex items-center gap-1.5 font-readout text-[9px] uppercase tracking-[0.22em] text-[var(--muted)]">
+        {live && (
+          <span
+            className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--red)] text-[var(--red)]"
+            style={{ animation: "neuro-pulse 1.5s ease-in-out infinite" }}
+          />
+        )}
         {label}
       </div>
-      <div className="font-roboto-slab text-2xl font-black leading-tight tabular-nums">
-        {value}
+      <div className="flex items-baseline gap-1">
+        <span
+          className="font-telemetry text-[1.7rem] font-bold leading-none tabular-nums"
+          style={{ color: accent }}
+        >
+          {value}
+        </span>
+        {unit && (
+          <span className="font-readout text-[11px] text-[var(--muted)]">{unit}</span>
+        )}
       </div>
-      {sub && (
-        <div className="font-mono text-[10px] uppercase tracking-widest text-[#f7c948]/80">
-          {sub}
-        </div>
-      )}
     </div>
   );
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+function DeltaChip({ delta }: { delta: number }) {
+  const tone =
+    delta <= 0.5 ? "var(--mint)" : delta <= 1.5 ? "var(--amber)" : "var(--muted)";
+  const sign = delta >= 0 ? "+" : "−";
   return (
-    <div className="rounded-lg border border-white/15 bg-white/[0.03] p-3">
-      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
-        {title}
+    <span
+      className="rounded-sm border px-1.5 py-0.5 font-readout text-[10px] tabular-nums"
+      style={{ borderColor: tone, color: tone }}
+    >
+      Δ {sign}
+      {Math.abs(delta).toFixed(1)}s
+    </span>
+  );
+}
+
+function HeaderStat({
+  label,
+  value,
+  accent = "var(--text)",
+}: {
+  label: string;
+  value: string;
+  accent?: string;
+}) {
+  return (
+    <div className="text-right">
+      <div className="font-readout text-[9px] uppercase tracking-[0.3em] text-[var(--muted)]">
+        {label}
       </div>
-      {children}
+      <div
+        className="font-telemetry text-xl font-semibold uppercase leading-tight tabular-nums"
+        style={{ color: accent }}
+      >
+        {value}
+      </div>
     </div>
+  );
+}
+
+function LED({ on, color = "var(--mint)" }: { on: boolean; color?: string }) {
+  return (
+    <span
+      className="inline-block h-2 w-2 rounded-full"
+      style={{
+        background: on ? color : "var(--muted)",
+        color,
+        animation: on ? "neuro-pulse 1.8s ease-in-out infinite" : "none",
+      }}
+    />
+  );
+}
+
+function Tag({ children, on }: { children: React.ReactNode; on?: boolean }) {
+  return (
+    <span className="flex items-center gap-1.5 font-readout text-[9px] uppercase tracking-[0.25em] text-[var(--muted)]">
+      {on && <LED on color="var(--red)" />}
+      {children}
+    </span>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="font-readout text-[9px] uppercase tracking-[0.22em] text-[var(--muted)]">
+      {children}
+    </span>
+  );
+}
+
+function Switch({
+  on,
+  onClick,
+  label,
+  title,
+}: {
+  on: boolean;
+  onClick: () => void;
+  label: string;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={on}
+      title={title}
+      className="flex items-center gap-2 font-readout text-[10px] uppercase tracking-[0.2em]"
+    >
+      <span
+        className={`relative h-4 w-7 rounded-sm border transition-colors ${
+          on ? "border-[var(--cyan)] bg-[var(--cyan)]/20" : "border-[var(--line-2)]"
+        }`}
+      >
+        <span
+          className={`absolute top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-[1px] transition-all ${
+            on
+              ? "left-[calc(100%-0.8rem)] bg-[var(--cyan)]"
+              : "left-0.5 bg-[var(--muted)]"
+          }`}
+        />
+      </span>
+      <span className={on ? "text-[var(--text)]" : "text-[var(--muted)]"}>{label}</span>
+    </button>
+  );
+}
+
+function DeckButton({
+  onClick,
+  title,
+  children,
+  tone = "line",
+}: {
+  onClick: () => void;
+  title?: string;
+  children: React.ReactNode;
+  tone?: "line" | "danger" | "amber";
+}) {
+  const tones: Record<string, string> = {
+    line: "border-[var(--line-2)] text-[var(--muted)] hover:border-[var(--cyan)] hover:text-[var(--text)]",
+    danger: "border-[var(--red)]/50 text-[var(--red)] hover:bg-[var(--red)] hover:text-black",
+    amber: "border-[var(--amber)] bg-[var(--amber)] text-black hover:brightness-110",
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`rounded-sm border px-3 py-2 font-readout text-[10px] uppercase tracking-[0.2em] transition-colors ${tones[tone]}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
+      <path d="M2 1.5v9l8-4.5z" />
+    </svg>
+  );
+}
+
+function PauseIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden>
+      <rect x="2" y="1.5" width="3" height="9" />
+      <rect x="7" y="1.5" width="3" height="9" />
+    </svg>
   );
 }

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -4,11 +4,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { mulberry32 } from "../../_lib/geometry";
 import type { Network } from "../../_lib/nn";
 import { clearWorld, loadWorld, saveWorld } from "../../_lib/persistence";
-import { createCar } from "../../_lib/car";
+import { LAPS_TO_FINISH, createCar, stepCar, type Car } from "../../_lib/car";
 import { buildTrack } from "../../_lib/track";
 import { drawWorld } from "../../_lib/render";
-import { LAPS_TO_FINISH } from "../../_lib/car";
 import { idealRunTicks } from "../../_lib/optimum";
+import { populationFrom } from "../../_lib/genetic";
+import { parseBrain, serializeBrain } from "../../_lib/brainIO";
 import {
   DEFAULT_CONFIG,
   activeCount,
@@ -29,7 +30,10 @@ const HUD_EVERY = 6;
 // Nominal ticks per second, for turning finish-tick counts into a time.
 const TICKS_PER_SEC = 60;
 
+type Mode = "evolve" | "solo";
+
 interface Stats {
+  mode: Mode;
   generation: number;
   active: number;
   pop: number;
@@ -38,9 +42,14 @@ interface Stats {
   idealTicks: number;
   runTimes: number[];
   leaderNet: Network | null;
+  // Solo-mode fields.
+  soloLaps: number;
+  soloRunTicks: number;
+  soloBestTicks: number;
 }
 
 const EMPTY_STATS: Stats = {
+  mode: "evolve",
   generation: 1,
   active: 0,
   pop: DEFAULT_CONFIG.populationSize,
@@ -49,6 +58,9 @@ const EMPTY_STATS: Stats = {
   idealTicks: 0,
   runTimes: [],
   leaderNet: null,
+  soloLaps: 0,
+  soloRunTicks: 0,
+  soloBestTicks: 0,
 };
 
 function formatTime(ticks: number): string {
@@ -68,23 +80,48 @@ export function Neuroevolution() {
   const sensorsRef = useRef(true);
   const savedGenRef = useRef(0);
 
+  // Solo mode: race one champion brain on a loop, no evolution.
+  const modeRef = useRef<Mode>("evolve");
+  const championRef = useRef<Network | null>(null);
+  const soloCarRef = useRef<Car | null>(null);
+  const soloBestRef = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const [stats, setStats] = useState<Stats>(EMPTY_STATS);
   const [paused, setPaused] = useState(false);
   const [speed, setSpeed] = useState(2);
   const [sensors, setSensors] = useState(true);
   const [mutationRate, setMutationRate] = useState(DEFAULT_CONFIG.mutationRate);
   const [varyTrack, setVaryTrack] = useState(DEFAULT_CONFIG.varyTrack);
+  const [mode, setMode] = useState<Mode>("evolve");
+  const [ioMsg, setIoMsg] = useState("");
 
   const flush = useCallback(() => {
     const w = worldRef.current;
     if (!w) return;
+    if (modeRef.current === "solo") {
+      const car = soloCarRef.current;
+      const gateCount = w.track.gates.length;
+      setStats((prev) => ({
+        ...prev,
+        mode: "solo",
+        idealTicks: idealRunTicks(w.track),
+        leaderNet: championRef.current,
+        soloLaps: car ? Math.min(LAPS_TO_FINISH, Math.floor(car.gatesPassed / gateCount)) : 0,
+        soloRunTicks: car ? car.ticks : 0,
+        soloBestTicks: soloBestRef.current,
+      }));
+      return;
+    }
     const lead = leader(w);
     const genTicks = bestFinishTicks(w);
     const bestTicks =
       genTicks > 0 && (w.bestTicks === 0 || genTicks < w.bestTicks)
         ? genTicks
         : w.bestTicks;
-    setStats({
+    setStats((prev) => ({
+      ...prev,
+      mode: "evolve",
       generation: w.generation,
       active: activeCount(w),
       pop: w.cars.length,
@@ -93,7 +130,16 @@ export function Neuroevolution() {
       idealTicks: idealRunTicks(w.track),
       runTimes: w.timeHistory.map((t) => t / 60),
       leaderNet: lead ? lead.net : null,
-    });
+    }));
+  }, []);
+
+  // The brain currently in the spotlight: the champion in solo, else the
+  // fittest of the population.
+  const spotlightNet = useCallback((): Network | null => {
+    if (championRef.current && modeRef.current === "solo") return championRef.current;
+    const w = worldRef.current;
+    if (!w) return null;
+    return leader(w)?.net ?? w.cars[0]?.net ?? null;
   }, []);
 
   // Start a new track. keepBrains carries the current population over (watch
@@ -122,6 +168,9 @@ export function Neuroevolution() {
       }
       worldRef.current = world;
       savedGenRef.current = world.generation;
+      // A new track invalidates the solo run (times are track-specific).
+      soloCarRef.current = null;
+      soloBestRef.current = 0;
       saveWorld(world);
       flush();
     },
@@ -160,7 +209,31 @@ export function Neuroevolution() {
 
     const loop = () => {
       const w = worldRef.current;
-      if (w) {
+      if (w && modeRef.current === "solo") {
+        const brain = championRef.current;
+        if (brain) {
+          if (!soloCarRef.current) soloCarRef.current = createCar(brain, w.track);
+          if (!pausedRef.current) {
+            for (let s = 0; s < speedRef.current; s++) {
+              const car = soloCarRef.current;
+              stepCar(car, w.track);
+              if (!car.alive || car.done) {
+                if (
+                  car.done &&
+                  (soloBestRef.current === 0 || car.finishTicks < soloBestRef.current)
+                ) {
+                  soloBestRef.current = car.finishTicks;
+                }
+                soloCarRef.current = createCar(brain, w.track); // loop the run
+                break;
+              }
+            }
+          }
+          const solo = soloCarRef.current;
+          drawWorld(ctx, { ...w, cars: solo ? [solo] : [] }, sensorsRef.current);
+        }
+        if (frame % HUD_EVERY === 0) flush();
+      } else if (w) {
         if (!pausedRef.current) {
           for (let s = 0; s < speedRef.current; s++) {
             stepWorld(w, configRef.current, randRef.current);
@@ -203,6 +276,96 @@ export function Neuroevolution() {
     setVaryTrack(next);
   };
 
+  const enterSolo = useCallback(
+    (net: Network | null) => {
+      const brain = net ?? spotlightNet();
+      if (!brain) return;
+      championRef.current = brain;
+      soloCarRef.current = null;
+      soloBestRef.current = 0;
+      modeRef.current = "solo";
+      setMode("solo");
+      flush();
+    },
+    [flush, spotlightNet],
+  );
+
+  const toggleSolo = () => {
+    if (modeRef.current === "solo") {
+      modeRef.current = "evolve";
+      setMode("evolve");
+      soloCarRef.current = null;
+      flush();
+    } else {
+      enterSolo(null);
+    }
+  };
+
+  const downloadBrain = () => {
+    const net = spotlightNet();
+    const w = worldRef.current;
+    if (!net) return;
+    const runTicks = modeRef.current === "solo" ? soloBestRef.current : w?.bestTicks ?? 0;
+    const text = serializeBrain(net, {
+      generation: w?.generation,
+      runSeconds: runTicks ? runTicks / TICKS_PER_SEC : undefined,
+    });
+    const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `neuro-brain-gen${w?.generation ?? 0}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setIoMsg("Brain downloaded");
+  };
+
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-uploading the same file later
+    if (!file) return;
+    file.text().then((text) => {
+      try {
+        enterSolo(parseBrain(text));
+        setIoMsg("Brain loaded — racing solo");
+      } catch (err) {
+        setIoMsg(err instanceof Error ? err.message : "Could not load brain");
+      }
+    });
+  };
+
+  const breedFromChampion = () => {
+    const w = worldRef.current;
+    const net = spotlightNet();
+    if (!w || !net) return;
+    clearWorld();
+    const cfg = configRef.current;
+    const cars = populationFrom(
+      net,
+      cfg.populationSize,
+      cfg.mutationRate,
+      cfg.mutationStrength,
+      randRef.current,
+    ).map((n) => createCar(n, w.track));
+    const world: World = {
+      track: w.track,
+      cars,
+      generation: 1,
+      step: 0,
+      bestEver: 0,
+      bestTicks: 0,
+      history: [],
+      timeHistory: [],
+    };
+    worldRef.current = world;
+    savedGenRef.current = 1;
+    soloCarRef.current = null;
+    modeRef.current = "evolve";
+    setMode("evolve");
+    saveWorld(world);
+    flush();
+    setIoMsg("Seeded a fresh population from the champion");
+  };
+
   return (
     <div className="min-h-full bg-[#0d0d0d] text-[#fffef5]">
       <div className="mx-auto max-w-6xl px-4 py-8 sm:py-10">
@@ -237,14 +400,29 @@ export function Neuroevolution() {
           {/* Side panel */}
           <div className="flex flex-col gap-4">
             <div className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/15 bg-white/15">
-              <Stat label="Generation" value={String(stats.generation)} />
-              <Stat label="Driving" value={`${stats.active} / ${stats.pop}`} />
-              <Stat label="This gen" value={formatTime(stats.genTicks)} />
-              <Stat
-                label="Fastest run"
-                value={formatTime(stats.bestTicks)}
-                sub={`${LAPS_TO_FINISH} laps`}
-              />
+              {stats.mode === "solo" ? (
+                <>
+                  <Stat label="Mode" value="Solo" />
+                  <Stat label="Laps" value={`${stats.soloLaps} / ${LAPS_TO_FINISH}`} />
+                  <Stat label="This run" value={formatTime(stats.soloRunTicks)} />
+                  <Stat
+                    label="Best run"
+                    value={formatTime(stats.soloBestTicks)}
+                    sub={`${LAPS_TO_FINISH} laps`}
+                  />
+                </>
+              ) : (
+                <>
+                  <Stat label="Generation" value={String(stats.generation)} />
+                  <Stat label="Driving" value={`${stats.active} / ${stats.pop}`} />
+                  <Stat label="This gen" value={formatTime(stats.genTicks)} />
+                  <Stat
+                    label="Fastest run"
+                    value={formatTime(stats.bestTicks)}
+                    sub={`${LAPS_TO_FINISH} laps`}
+                  />
+                </>
+              )}
             </div>
 
             {/* Physics-limit target for this exact track. */}
@@ -372,6 +550,62 @@ export function Neuroevolution() {
           auto-saves · refresh resumes · new track keeps the brains · fresh start wipes them
           {varyTrack ? " · varying track each generation" : ""}
         </p>
+
+        {/* Champion: spotlight, save/load, or breed from the best brain */}
+        <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg border border-white/15 bg-white/[0.03] p-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+            Champion
+          </span>
+          <button
+            type="button"
+            onClick={toggleSolo}
+            aria-pressed={mode === "solo"}
+            title="Race just the best brain, on its own, looping"
+            className={`rounded-md border px-3 py-2 font-mono text-xs uppercase tracking-widest transition-colors ${
+              mode === "solo"
+                ? "border-[#f7c948] bg-[#f7c948] text-black"
+                : "border-white/20 text-white/70 hover:bg-white/10"
+            }`}
+          >
+            {mode === "solo" ? "Back to evolving" : "Race solo"}
+          </button>
+          <button
+            type="button"
+            onClick={downloadBrain}
+            title="Save the best brain to a file"
+            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
+          >
+            Download
+          </button>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            title="Load a brain from a file and race it solo"
+            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
+          >
+            Upload
+          </button>
+          <button
+            type="button"
+            onClick={breedFromChampion}
+            title="Start a fresh population evolved from this brain"
+            className="rounded-md border border-white/20 px-3 py-2 font-mono text-xs uppercase tracking-widest text-white/70 transition-colors hover:bg-white hover:text-black"
+          >
+            Breed from it
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            onChange={onFile}
+            className="hidden"
+          />
+          {ioMsg && (
+            <span className="ml-auto font-mono text-[10px] tracking-widest text-[#34d399]">
+              {ioMsg}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Sparkline.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Sparkline.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+const W = 240;
+const H = 64;
+
+// Best finish time per generation (seconds; 0 = no finisher that gen), drawn
+// so faster is higher. The track optimum is shown as a dashed reference line.
+export function Sparkline({
+  data,
+  optimum,
+}: {
+  data: number[];
+  optimum: number;
+}) {
+  const points = data
+    .map((t, i) => ({ i, t }))
+    .filter((p) => p.t > 0);
+
+  if (points.length < 2) {
+    return (
+      <div className="flex h-16 items-center justify-center font-mono text-[11px] uppercase tracking-widest text-white/30">
+        no finishers yet…
+      </div>
+    );
+  }
+
+  const times = points.map((p) => p.t);
+  const hasOpt = optimum > 0;
+  let lo = Math.min(...times, hasOpt ? optimum : Infinity);
+  let hi = Math.max(...times);
+  if (hi - lo < 0.2) hi = lo + 0.2; // keep a flat, converged line readable
+  const pad = (hi - lo) * 0.12;
+  lo -= pad;
+  hi += pad;
+
+  const n = data.length;
+  const x = (i: number) => (n <= 1 ? 0 : (i / (n - 1)) * W);
+  // Faster time -> nearer the top.
+  const y = (t: number) => ((t - lo) / (hi - lo)) * H;
+
+  const path = points.map((p) => `${x(p.i)},${y(p.t).toFixed(1)}`);
+  const line = `M ${path.join(" L ")}`;
+  const last = points[points.length - 1];
+  const area = `${line} L ${x(last.i)},${H} L ${x(points[0].i)},${H} Z`;
+  const optY = hasOpt ? y(optimum) : 0;
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="h-16 w-full" role="img" aria-label="Best run time per generation">
+      <path d={area} fill="#f7c948" fillOpacity={0.15} />
+      <path d={line} fill="none" stroke="#f7c948" strokeWidth={2} strokeLinejoin="round" />
+      {hasOpt && optY >= 0 && optY <= H && (
+        <line
+          x1={0}
+          y1={optY}
+          x2={W}
+          y2={optY}
+          stroke="#34d399"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Sparkline.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Sparkline.tsx
@@ -2,9 +2,11 @@
 
 const W = 240;
 const H = 64;
+const AMBER = "#f7c948";
+const MINT = "#35d6a0";
 
-// Best finish time per generation (seconds; 0 = no finisher that gen), drawn
-// so faster is higher. The track optimum is shown as a dashed reference line.
+// Best finish time per generation (seconds; 0 = no finisher that gen), drawn as
+// an oscilloscope trace so faster is higher. The track optimum is a dashed line.
 export function Sparkline({
   data,
   optimum,
@@ -12,13 +14,11 @@ export function Sparkline({
   data: number[];
   optimum: number;
 }) {
-  const points = data
-    .map((t, i) => ({ i, t }))
-    .filter((p) => p.t > 0);
+  const points = data.map((t, i) => ({ i, t })).filter((p) => p.t > 0);
 
   if (points.length < 2) {
     return (
-      <div className="flex h-16 items-center justify-center font-mono text-[11px] uppercase tracking-widest text-white/30">
+      <div className="flex h-16 items-center justify-center font-readout text-[10px] uppercase tracking-[0.25em] text-[var(--muted)]">
         no finishers yet…
       </div>
     );
@@ -45,16 +45,51 @@ export function Sparkline({
   const optY = hasOpt ? y(optimum) : 0;
 
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="h-16 w-full" role="img" aria-label="Best run time per generation">
-      <path d={area} fill="#f7c948" fillOpacity={0.15} />
-      <path d={line} fill="none" stroke="#f7c948" strokeWidth={2} strokeLinejoin="round" />
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="h-16 w-full"
+      role="img"
+      aria-label="Best run time per generation"
+    >
+      <defs>
+        <linearGradient id="neuro-trace-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={AMBER} stopOpacity={0.22} />
+          <stop offset="100%" stopColor={AMBER} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+
+      {/* faint gridlines */}
+      {[0.25, 0.5, 0.75].map((f) => (
+        <line
+          key={f}
+          x1={0}
+          y1={H * f}
+          x2={W}
+          y2={H * f}
+          stroke="rgba(150,180,205,0.10)"
+          strokeWidth={1}
+        />
+      ))}
+
+      <path d={area} fill="url(#neuro-trace-fill)" />
+      <path
+        d={line}
+        fill="none"
+        stroke={AMBER}
+        strokeWidth={1.75}
+        strokeLinejoin="round"
+        style={{ filter: `drop-shadow(0 0 2px ${AMBER})` }}
+      />
+      {/* leading marker at the latest generation */}
+      <circle cx={x(last.i)} cy={y(last.t)} r={2.4} fill={AMBER} />
+
       {hasOpt && optY >= 0 && optY <= H && (
         <line
           x1={0}
           y1={optY}
           x2={W}
           y2={optY}
-          stroke="#34d399"
+          stroke={MINT}
           strokeWidth={1}
           strokeDasharray="3 3"
         />

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/index.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/index.tsx
@@ -1,0 +1,1 @@
+export { Neuroevolution } from "./Neuroevolution";

--- a/src/app/playgrounds/neuroevolution/_lib/brainIO.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/brainIO.test.ts
@@ -1,0 +1,34 @@
+import { BRAIN_SHAPE } from "./car";
+import { mulberry32 } from "./geometry";
+import { createNetwork } from "./nn";
+import { parseBrain, serializeBrain } from "./brainIO";
+
+const net = createNetwork(BRAIN_SHAPE, mulberry32(1));
+
+describe("brain round-trip", () => {
+  it("parses back a serialized brain identically", () => {
+    const parsed = parseBrain(serializeBrain(net, { generation: 5 }));
+    expect(parsed).toEqual(net);
+  });
+});
+
+describe("parseBrain validation", () => {
+  it("rejects non-JSON", () => {
+    expect(() => parseBrain("nope")).toThrow(/JSON/);
+  });
+
+  it("rejects the wrong format", () => {
+    expect(() => parseBrain(JSON.stringify({ hello: 1 }))).toThrow(/brain file/);
+  });
+
+  it("rejects a mismatched shape", () => {
+    const wrong = createNetwork([3, 3, 2], mulberry32(2));
+    expect(() => parseBrain(serializeBrain(wrong))).toThrow(/shape/);
+  });
+
+  it("rejects a layer whose weights are the wrong length", () => {
+    const broken = createNetwork(BRAIN_SHAPE, mulberry32(3));
+    broken.layers[0].w.pop(); // now w.length !== inSize * outSize
+    expect(() => parseBrain(serializeBrain(broken))).toThrow(/malformed layer/);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/brainIO.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/brainIO.ts
@@ -1,0 +1,75 @@
+// Serialize a brain to a portable JSON file and read it back, validating with
+// zod that its shape matches the current network layout.
+
+import { z } from "zod";
+import { BRAIN_SHAPE } from "./car";
+import type { Network } from "./nn";
+
+const FORMAT = "neuroevolution-brain";
+const VERSION = 1;
+
+export interface BrainMeta {
+  generation?: number;
+  runSeconds?: number;
+}
+
+function shapeOf(net: Network): number[] {
+  return [net.layers[0]?.inSize, ...net.layers.map((l) => l.outSize)];
+}
+
+export function serializeBrain(net: Network, meta: BrainMeta = {}): string {
+  return JSON.stringify(
+    { format: FORMAT, version: VERSION, shape: shapeOf(net), meta, net },
+    null,
+    2,
+  );
+}
+
+const layerSchema = z
+  .object({
+    inSize: z.number().int().positive(),
+    outSize: z.number().int().positive(),
+    w: z.array(z.number()),
+    b: z.array(z.number()),
+  })
+  .refine((l) => l.w.length === l.inSize * l.outSize && l.b.length === l.outSize, {
+    error: "Brain file has a malformed layer",
+  });
+
+const brainFileSchema = z
+  .object({
+    format: z.literal(FORMAT, { error: "Not a neuroevolution brain file" }),
+    version: z.number().optional(),
+    net: z.object({ layers: z.array(layerSchema).min(1) }),
+  })
+  .superRefine((data, ctx) => {
+    const shape = [
+      data.net.layers[0].inSize,
+      ...data.net.layers.map((l) => l.outSize),
+    ];
+    if (
+      shape.length !== BRAIN_SHAPE.length ||
+      shape.some((v, i) => v !== BRAIN_SHAPE[i])
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Brain shape [${shape}] does not match this sim [${BRAIN_SHAPE}]`,
+      });
+    }
+  });
+
+// Parse and validate a brain file. Throws a human-readable Error on any problem.
+export function parseBrain(text: string): Network {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error("Not valid JSON");
+  }
+
+  const result = brainFileSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(result.error.issues[0]?.message ?? "Invalid brain file");
+  }
+  return result.data.net as Network;
+}

--- a/src/app/playgrounds/neuroevolution/_lib/car.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/car.test.ts
@@ -1,0 +1,70 @@
+import { mulberry32 } from "./geometry";
+import type { Network } from "./nn";
+import { buildTrack } from "./track";
+import { SENSOR_ANGLES, SENSOR_RANGE, createCar, stepCar } from "./car";
+
+const track = buildTrack({ width: 800, height: 600, points: 48 }, mulberry32(1));
+const INPUTS = SENSOR_ANGLES.length + 1;
+
+// A hand-built single-hidden-layer brain whose output depends only on the two
+// output biases, so a test can force "drive straight" or "sit still" regardless
+// of inputs. Independent of BRAIN_SHAPE: stepCar only reads outputs 0 and 1.
+function fixedBrain(steerBias: number, throttleBias: number): Network {
+  return {
+    layers: [
+      { inSize: INPUTS, outSize: 4, w: new Array(INPUTS * 4).fill(0), b: new Array(4).fill(0) },
+      { inSize: 4, outSize: 2, w: new Array(4 * 2).fill(0), b: [steerBias, throttleBias] },
+    ],
+  };
+}
+
+describe("createCar", () => {
+  it("starts alive at the track start pose", () => {
+    const car = createCar(fixedBrain(0, 0), track);
+    expect(car.alive).toBe(true);
+    expect(car.gatesPassed).toBe(0);
+    expect(car.x).toBeCloseTo(track.start.x);
+    expect(car.y).toBeCloseTo(track.start.y);
+  });
+});
+
+describe("stepCar", () => {
+  it("populates sensor readings within range", () => {
+    const car = createCar(fixedBrain(0, 5), track);
+    stepCar(car, track);
+    expect(car.sensors).toHaveLength(SENSOR_ANGLES.length);
+    for (const d of car.sensors) {
+      expect(d).toBeGreaterThanOrEqual(0);
+      expect(d).toBeLessThanOrEqual(SENSOR_RANGE);
+    }
+  });
+
+  it("earns fitness as it moves toward the next gate", () => {
+    const car = createCar(fixedBrain(0, 5), track); // full throttle, straight
+    for (let i = 0; i < 20 && car.alive; i++) stepCar(car, track);
+    expect(car.fitness).toBeGreaterThan(0);
+  });
+
+  it("culls a car that just sits there (stalled)", () => {
+    const car = createCar(fixedBrain(0, -5), track); // brakes, never moves
+    // Run well past the stale cull window regardless of its exact value.
+    for (let i = 0; i < 400; i++) stepCar(car, track);
+    expect(car.alive).toBe(false);
+    expect(car.gatesPassed).toBe(0);
+  });
+
+  it("eventually crashes a car driving blindly straight", () => {
+    const car = createCar(fixedBrain(0, 5), track);
+    for (let i = 0; i < 800 && car.alive; i++) stepCar(car, track);
+    expect(car.alive).toBe(false);
+  });
+
+  it("does nothing once dead", () => {
+    const car = createCar(fixedBrain(0, 5), track);
+    car.alive = false;
+    const snapshot = { ...car };
+    stepCar(car, track);
+    expect(car.x).toBe(snapshot.x);
+    expect(car.y).toBe(snapshot.y);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/car.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/car.ts
@@ -6,13 +6,25 @@ import { rayHit, segmentsIntersect } from "./geometry";
 import { forward, type Network } from "./nn";
 import type { Track } from "./track";
 
-// Sensor whiskers, relative to the car's heading.
-export const SENSOR_ANGLES = [-Math.PI / 3, -Math.PI / 6, 0, Math.PI / 6, Math.PI / 3];
-export const SENSOR_RANGE = 170;
+// Sensor whiskers, relative to the car's heading: wide side coverage plus fine
+// forward resolution so the car can read a corner before it arrives.
+const DEG = Math.PI / 180;
+export const SENSOR_ANGLES = [
+  -90 * DEG,
+  -45 * DEG,
+  -20 * DEG,
+  0,
+  20 * DEG,
+  45 * DEG,
+  90 * DEG,
+];
+// Longer range gives genuine look-ahead: the forward whiskers spot walls sooner,
+// so a brain can learn to brake early for a corner it can't yet be next to.
+export const SENSOR_RANGE = 260;
 
 // Network shape: one input per sensor plus current speed, two hidden layers,
 // then steering + throttle.
-export const BRAIN_SHAPE = [SENSOR_ANGLES.length + 1, 10, 8, 2];
+export const BRAIN_SHAPE = [SENSOR_ANGLES.length + 1, 12, 8, 2];
 
 // The car is deliberately overpowered for the track: top speed is high and
 // grip (turn rate) is modest, so the full-speed turn radius R* = MAX_SPEED /

--- a/src/app/playgrounds/neuroevolution/_lib/car.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/car.ts
@@ -1,0 +1,171 @@
+// A car: kinematic body, wall-distance sensors, and an NN brain. One step
+// reads the sensors, asks the brain for steering + throttle, moves, then checks
+// for a crash or a gate crossing.
+
+import { rayHit, segmentsIntersect } from "./geometry";
+import { forward, type Network } from "./nn";
+import type { Track } from "./track";
+
+// Sensor whiskers, relative to the car's heading.
+export const SENSOR_ANGLES = [-Math.PI / 3, -Math.PI / 6, 0, Math.PI / 6, Math.PI / 3];
+export const SENSOR_RANGE = 170;
+
+// Network shape: one input per sensor plus current speed, two hidden layers,
+// then steering + throttle.
+export const BRAIN_SHAPE = [SENSOR_ANGLES.length + 1, 10, 8, 2];
+
+// The car is deliberately overpowered for the track: top speed is high and
+// grip (turn rate) is modest, so the full-speed turn radius R* = MAX_SPEED /
+// TURN_RATE is far larger than the track's corners. Mastering when to brace and
+// how much to brake is a deep skill that takes many generations to refine.
+export const MAX_SPEED = 5.8;
+export const ACCEL = 0.22;
+// Braking bites harder than the throttle, like a real car, so the winning line
+// is "flat out, brake hard, apex, accelerate out" rather than crawling.
+export const BRAKE = 0.45;
+const FRICTION = 0.02;
+// Angular velocity per tick at full steer. Constant (not speed-scaled), so the
+// turn radius widens with speed: fast corners can only be taken by slowing down.
+export const TURN_RATE = 0.06;
+// Below this speed the car can't steer, so a parked car can't spin in place.
+const MIN_TURN_SPEED = 0.3;
+// Ticks a car may go without reaching a new gate before it's culled as stalled.
+// Generous, since a good line may crawl through a hairpin.
+const STALE_STEPS = 120;
+
+// The goal is a clean run of this many laps, as fast as possible.
+export const LAPS_TO_FINISH = 3;
+// Reference tick budget for scoring finish speed (a faster finish scores
+// higher). Doubles as the generation's hard safety cap.
+export const FINISH_TIME_BUDGET = 3000;
+
+export interface Car {
+  x: number;
+  y: number;
+  angle: number;
+  speed: number;
+  alive: boolean;
+  // Set once the car has completed the target laps; it then stops simulating.
+  done: boolean;
+  net: Network;
+  nextGate: number;
+  gatesPassed: number;
+  fitness: number;
+  stale: number;
+  // Ticks this car has been simulated; the tick it finished on (0 if unfinished).
+  ticks: number;
+  finishTicks: number;
+  // Last sensor distances (clamped to SENSOR_RANGE), kept for rendering.
+  sensors: number[];
+}
+
+export function createCar(net: Network, track: Track): Car {
+  return {
+    x: track.start.x,
+    y: track.start.y,
+    angle: track.start.angle,
+    speed: 0,
+    alive: true,
+    done: false,
+    net,
+    nextGate: 1 % track.gates.length,
+    gatesPassed: 0,
+    fitness: 0,
+    stale: 0,
+    ticks: 0,
+    finishTicks: 0,
+    sensors: SENSOR_ANGLES.map(() => SENSOR_RANGE),
+  };
+}
+
+// Cast every whisker and return the nearest wall distance for each.
+function readSensors(car: Car, track: Track): number[] {
+  const out = new Array(SENSOR_ANGLES.length);
+  for (let s = 0; s < SENSOR_ANGLES.length; s++) {
+    const a = car.angle + SENSOR_ANGLES[s];
+    const dx = Math.cos(a);
+    const dy = Math.sin(a);
+    let nearest = SENSOR_RANGE;
+    for (const w of track.walls) {
+      const t = rayHit(car.x, car.y, dx, dy, w.ax, w.ay, w.bx, w.by);
+      if (t < nearest) nearest = t;
+    }
+    out[s] = nearest;
+  }
+  return out;
+}
+
+// Advance one car by a single tick. No-op once it has crashed.
+export function stepCar(car: Car, track: Track): void {
+  if (!car.alive || car.done) return;
+  car.ticks += 1;
+
+  const sensors = readSensors(car, track);
+  car.sensors = sensors;
+
+  const inputs = new Array(SENSOR_ANGLES.length + 1);
+  for (let i = 0; i < sensors.length; i++) inputs[i] = sensors[i] / SENSOR_RANGE;
+  inputs[sensors.length] = car.speed / MAX_SPEED;
+
+  // Throttle is bipolar: positive accelerates, negative brakes (harder).
+  const [steer, throttle] = forward(car.net, inputs);
+
+  car.speed += throttle * (throttle < 0 ? BRAKE : ACCEL);
+  car.speed *= 1 - FRICTION;
+  if (car.speed > MAX_SPEED) car.speed = MAX_SPEED;
+  if (car.speed < 0) car.speed = 0;
+  // Constant angular velocity means the turn radius grows with speed, so a tight
+  // corner demands braking. That speed/steer tradeoff is the skill that keeps
+  // cars improving long after they can merely stay on the road.
+  if (car.speed > MIN_TURN_SPEED) car.angle += steer * TURN_RATE;
+
+  const px = car.x;
+  const py = car.y;
+  const nx = px + Math.cos(car.angle) * car.speed;
+  const ny = py + Math.sin(car.angle) * car.speed;
+
+  for (const w of track.walls) {
+    if (segmentsIntersect(px, py, nx, ny, w.ax, w.ay, w.bx, w.by)) {
+      car.alive = false;
+      return;
+    }
+  }
+
+  car.x = nx;
+  car.y = ny;
+
+  const gate = track.gates[car.nextGate];
+  if (segmentsIntersect(px, py, nx, ny, gate.ax, gate.ay, gate.bx, gate.by)) {
+    car.gatesPassed += 1;
+    car.nextGate = (car.nextGate + 1) % track.gates.length;
+    car.stale = 0;
+  } else {
+    car.stale += 1;
+    if (car.stale > STALE_STEPS) {
+      car.alive = false;
+    }
+  }
+
+  const target = LAPS_TO_FINISH * track.gates.length;
+  if (car.gatesPassed >= target) {
+    car.done = true;
+    car.finishTicks = car.ticks;
+  }
+
+  car.fitness = fitness(car, track, target);
+}
+
+// A finished car scores above any unfinished one, ranked by how fast it went.
+// An unfinished car scores by distance covered, with a smooth fraction toward
+// the next gate so even early, gate-less cars get a usable gradient.
+function fitness(car: Car, track: Track, target: number): number {
+  if (car.done) {
+    return target + Math.max(0, FINISH_TIME_BUDGET - car.finishTicks);
+  }
+  const gate = track.gates[car.nextGate];
+  const midX = (gate.ax + gate.bx) / 2;
+  const midY = (gate.ay + gate.by) / 2;
+  const d = Math.hypot(midX - car.x, midY - car.y);
+  const shaping = Math.max(0, Math.min(0.95, 1 - d / track.gateSpacing));
+  return car.gatesPassed + shaping;
+}

--- a/src/app/playgrounds/neuroevolution/_lib/fonts.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/fonts.ts
@@ -1,0 +1,18 @@
+import { Chakra_Petch, IBM_Plex_Mono } from "next/font/google";
+
+// Chakra Petch: squared, technical, lap-timer energy for the big readouts and
+// headings — the pit-wall display voice.
+export const display = Chakra_Petch({
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  variable: "--font-neuro-display",
+  display: "swap",
+});
+
+// IBM Plex Mono: engineering-instrument heritage for the dense labels and data.
+export const mono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-neuro-mono",
+  display: "swap",
+});

--- a/src/app/playgrounds/neuroevolution/_lib/genetic.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/genetic.test.ts
@@ -1,6 +1,12 @@
 import { mulberry32 } from "./geometry";
 import { createNetwork, type Network } from "./nn";
-import { computeStats, evolve, tournament, type Scored } from "./genetic";
+import {
+  computeStats,
+  evolve,
+  populationFrom,
+  tournament,
+  type Scored,
+} from "./genetic";
 
 function population(fitnesses: number[]): Scored[] {
   return fitnesses.map((fitness, i) => ({
@@ -54,6 +60,17 @@ describe("tournament", () => {
     let i = 0;
     const rand = () => seq[i++];
     expect(tournament(pop, 3, rand)).toBe(pop[4].net);
+  });
+});
+
+describe("populationFrom", () => {
+  it("keeps one exact clone of the seed and fills the rest", () => {
+    const seed = createNetwork([2, 2], mulberry32(1));
+    const pop = populationFrom(seed, 6, 0.5, 0.3, mulberry32(2));
+    expect(pop).toHaveLength(6);
+    expect(pop[0]).toEqual(seed); // first is an untouched clone
+    expect(pop[0]).not.toBe(seed); // but a copy, not the same reference
+    expect(pop[1]).not.toEqual(seed); // the rest are mutated
   });
 });
 

--- a/src/app/playgrounds/neuroevolution/_lib/genetic.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/genetic.test.ts
@@ -1,0 +1,70 @@
+import { mulberry32 } from "./geometry";
+import { createNetwork, type Network } from "./nn";
+import { computeStats, evolve, tournament, type Scored } from "./genetic";
+
+function population(fitnesses: number[]): Scored[] {
+  return fitnesses.map((fitness, i) => ({
+    net: createNetwork([2, 2], mulberry32(i + 1)),
+    fitness,
+  }));
+}
+
+const config = {
+  populationSize: 10,
+  eliteCount: 2,
+  tournamentSize: 3,
+  mutationRate: 0.1,
+  mutationStrength: 0.3,
+};
+
+describe("evolve", () => {
+  it("returns exactly populationSize brains", () => {
+    const next = evolve(population([1, 5, 3, 2, 4]), config, mulberry32(99));
+    expect(next).toHaveLength(10);
+  });
+
+  it("carries the fittest elite through unchanged", () => {
+    const pop = population([1, 5, 3, 2, 4]);
+    const fittest: Network = pop[1].net; // fitness 5
+    const next = evolve(pop, config, mulberry32(1));
+    expect(next[0]).toEqual(fittest);
+  });
+
+  it("with full elitism and no mutation, clones the whole population", () => {
+    const pop = population([3, 1, 2]);
+    const cloneAll = {
+      ...config,
+      populationSize: 3,
+      eliteCount: 3,
+      mutationRate: 0,
+    };
+    const next = evolve(pop, cloneAll, mulberry32(1));
+    // Sorted by fitness: [3, 2, 1].
+    expect(next[0]).toEqual(pop[0].net);
+    expect(next[1]).toEqual(pop[2].net);
+    expect(next[2]).toEqual(pop[1].net);
+  });
+});
+
+describe("tournament", () => {
+  it("returns the fittest of the sampled individuals", () => {
+    const pop = population([1, 2, 3, 4, 5]);
+    // rand() sequence maps to indices 0, 4, 2 -> fitnesses 1, 5, 3 -> winner idx 4.
+    const seq = [0.0, 0.99, 0.5];
+    let i = 0;
+    const rand = () => seq[i++];
+    expect(tournament(pop, 3, rand)).toBe(pop[4].net);
+  });
+});
+
+describe("computeStats", () => {
+  it("reports best and mean fitness", () => {
+    const stats = computeStats(population([2, 4, 6]));
+    expect(stats.best).toBe(6);
+    expect(stats.mean).toBeCloseTo(4);
+  });
+
+  it("handles an empty population", () => {
+    expect(computeStats([])).toEqual({ best: -Infinity, mean: 0 });
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/genetic.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/genetic.ts
@@ -3,6 +3,22 @@
 
 import { cloneNetwork, crossover, mutate, type Network } from "./nn";
 
+// Build a population seeded from a single brain: one exact clone plus mutated
+// copies. Used to start (or resume) evolution from a saved/uploaded champion.
+export function populationFrom(
+  net: Network,
+  size: number,
+  mutationRate: number,
+  mutationStrength: number,
+  rand: () => number,
+): Network[] {
+  const out: Network[] = [cloneNetwork(net)];
+  while (out.length < size) {
+    out.push(mutate(net, mutationRate, mutationStrength, rand));
+  }
+  return out;
+}
+
 export interface Scored {
   net: Network;
   fitness: number;

--- a/src/app/playgrounds/neuroevolution/_lib/genetic.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/genetic.ts
@@ -1,0 +1,67 @@
+// Turns a scored population into the next generation: keep a few elites intact,
+// then breed the rest by tournament selection, uniform crossover and mutation.
+
+import { cloneNetwork, crossover, mutate, type Network } from "./nn";
+
+export interface Scored {
+  net: Network;
+  fitness: number;
+}
+
+export interface EvolveConfig {
+  populationSize: number;
+  eliteCount: number;
+  tournamentSize: number;
+  mutationRate: number;
+  mutationStrength: number;
+}
+
+export interface GenerationStats {
+  best: number;
+  mean: number;
+}
+
+// Sample `k` individuals and return the fittest one's brain.
+export function tournament(
+  sorted: Scored[],
+  k: number,
+  rand: () => number,
+): Network {
+  let best = sorted[Math.floor(rand() * sorted.length)];
+  for (let i = 1; i < k; i++) {
+    const c = sorted[Math.floor(rand() * sorted.length)];
+    if (c.fitness > best.fitness) best = c;
+  }
+  return best.net;
+}
+
+export function evolve(
+  scored: Scored[],
+  config: EvolveConfig,
+  rand: () => number,
+): Network[] {
+  const sorted = [...scored].sort((a, b) => b.fitness - a.fitness);
+  const next: Network[] = [];
+
+  const elites = Math.min(config.eliteCount, sorted.length);
+  for (let i = 0; i < elites; i++) next.push(cloneNetwork(sorted[i].net));
+
+  while (next.length < config.populationSize) {
+    const a = tournament(sorted, config.tournamentSize, rand);
+    const b = tournament(sorted, config.tournamentSize, rand);
+    const child = crossover(a, b, rand);
+    next.push(mutate(child, config.mutationRate, config.mutationStrength, rand));
+  }
+
+  return next;
+}
+
+export function computeStats(scored: Scored[]): GenerationStats {
+  let best = -Infinity;
+  let sum = 0;
+  for (const s of scored) {
+    if (s.fitness > best) best = s.fitness;
+    sum += s.fitness;
+  }
+  return { best, mean: scored.length ? sum / scored.length : 0 };
+}

--- a/src/app/playgrounds/neuroevolution/_lib/geometry.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/geometry.test.ts
@@ -1,0 +1,61 @@
+import { gaussian, mulberry32, rayHit, segmentsIntersect } from "./geometry";
+
+describe("mulberry32", () => {
+  it("is deterministic for a given seed", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+
+  it("stays within [0, 1)", () => {
+    const r = mulberry32(7);
+    for (let i = 0; i < 1000; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe("gaussian", () => {
+  it("has roughly zero mean over many samples", () => {
+    const r = mulberry32(1);
+    let sum = 0;
+    const n = 20000;
+    for (let i = 0; i < n; i++) sum += gaussian(r);
+    expect(Math.abs(sum / n)).toBeLessThan(0.05);
+  });
+});
+
+describe("rayHit", () => {
+  it("hits a segment straight ahead and returns the distance", () => {
+    // Ray from origin pointing +x, wall crossing x=5.
+    expect(rayHit(0, 0, 1, 0, 5, -5, 5, 5)).toBeCloseTo(5);
+  });
+
+  it("misses a segment behind the ray", () => {
+    expect(rayHit(0, 0, 1, 0, -5, -5, -5, 5)).toBe(Infinity);
+  });
+
+  it("misses a segment the ray does not cross", () => {
+    expect(rayHit(0, 0, 1, 0, 5, 2, 5, 8)).toBe(Infinity);
+  });
+
+  it("returns Infinity when parallel", () => {
+    expect(rayHit(0, 0, 1, 0, 0, 1, 10, 1)).toBe(Infinity);
+  });
+});
+
+describe("segmentsIntersect", () => {
+  it("detects a clean crossing", () => {
+    expect(segmentsIntersect(0, 0, 10, 10, 0, 10, 10, 0)).toBe(true);
+  });
+
+  it("returns false for disjoint segments", () => {
+    expect(segmentsIntersect(0, 0, 1, 1, 5, 5, 6, 6)).toBe(false);
+  });
+
+  it("returns false for parallel segments", () => {
+    expect(segmentsIntersect(0, 0, 10, 0, 0, 1, 10, 1)).toBe(false);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/geometry.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/geometry.ts
@@ -1,0 +1,93 @@
+// Small geometry + RNG toolkit for the simulation. The ray/segment cores take
+// primitive numbers rather than objects: they run tens of thousands of times
+// per tick, so we keep them allocation-free.
+
+export interface Vec {
+  x: number;
+  y: number;
+}
+
+// Deterministic PRNG so a given seed replays identically (used in tests, and
+// lets the UI reset to a repeatable run). Returns a function in [0, 1).
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Standard-normal sample via Box-Muller, drawing from the supplied uniform RNG.
+export function gaussian(rand: () => number): number {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = rand();
+  while (v === 0) v = rand();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+// Distance a ray (origin o, unit direction d) travels before hitting segment
+// a-b, or Infinity if it misses. Assumes (dx, dy) is normalised.
+export function rayHit(
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const sx = bx - ax;
+  const sy = by - ay;
+  const denom = sx * dy - sy * dx;
+  if (Math.abs(denom) < 1e-9) return Infinity; // parallel
+  // Solve o + t*d = a + u*s. rx/ry is (a - o).
+  const rx = ax - ox;
+  const ry = ay - oy;
+  const u = (dx * ry - dy * rx) / denom; // position along the segment
+  if (u < 0 || u > 1) return Infinity;
+  const t = (sx * ry - sy * rx) / denom; // distance along the ray
+  return t >= 0 ? t : Infinity;
+}
+
+// Whether segments p1-p2 and p3-p4 cross. Used for collisions and gate passing.
+export function segmentsIntersect(
+  p1x: number,
+  p1y: number,
+  p2x: number,
+  p2y: number,
+  p3x: number,
+  p3y: number,
+  p4x: number,
+  p4y: number,
+): boolean {
+  const d1 = orient(p3x, p3y, p4x, p4y, p1x, p1y);
+  const d2 = orient(p3x, p3y, p4x, p4y, p2x, p2y);
+  const d3 = orient(p1x, p1y, p2x, p2y, p3x, p3y);
+  const d4 = orient(p1x, p1y, p2x, p2y, p4x, p4y);
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+      ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true;
+  }
+  return false;
+}
+
+// Signed area sign of triangle (ax,ay)-(bx,by)-(cx,cy).
+function orient(
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+  cx: number,
+  cy: number,
+): number {
+  return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+}
+
+export function dist(ax: number, ay: number, bx: number, by: number): number {
+  return Math.hypot(bx - ax, by - ay);
+}

--- a/src/app/playgrounds/neuroevolution/_lib/nn.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/nn.test.ts
@@ -1,0 +1,85 @@
+import { mulberry32 } from "./geometry";
+import {
+  cloneNetwork,
+  createNetwork,
+  crossover,
+  forward,
+  genomeLength,
+  mutate,
+} from "./nn";
+
+const shape = [6, 8, 2];
+
+describe("createNetwork", () => {
+  it("builds layers matching the shape", () => {
+    const net = createNetwork(shape, mulberry32(1));
+    expect(net.layers).toHaveLength(2);
+    expect(net.layers[0]).toMatchObject({ inSize: 6, outSize: 8 });
+    expect(net.layers[1]).toMatchObject({ inSize: 8, outSize: 2 });
+    expect(net.layers[0].w).toHaveLength(48);
+    expect(net.layers[0].b).toHaveLength(8);
+  });
+
+  it("reports the total genome length", () => {
+    const net = createNetwork(shape, mulberry32(1));
+    expect(genomeLength(net)).toBe(48 + 8 + 16 + 2);
+  });
+});
+
+describe("forward", () => {
+  it("produces one tanh-bounded value per output", () => {
+    const net = createNetwork(shape, mulberry32(2));
+    const out = forward(net, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
+    expect(out).toHaveLength(2);
+    for (const v of out) {
+      expect(v).toBeGreaterThan(-1);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("is deterministic for the same net and input", () => {
+    const net = createNetwork(shape, mulberry32(3));
+    const input = [0.9, 0.8, 0.7, 0.6, 0.5, 0.4];
+    expect(forward(net, input)).toEqual(forward(net, input));
+  });
+});
+
+describe("mutate", () => {
+  it("leaves the parent untouched", () => {
+    const parent = createNetwork(shape, mulberry32(4));
+    const before = parent.layers[0].w.slice();
+    mutate(parent, 1, 0.5, mulberry32(5));
+    expect(parent.layers[0].w).toEqual(before);
+  });
+
+  it("changes genes at rate 1 and none at rate 0", () => {
+    const parent = createNetwork(shape, mulberry32(6));
+    const changed = mutate(parent, 1, 0.5, mulberry32(7));
+    expect(changed.layers[0].w).not.toEqual(parent.layers[0].w);
+
+    const same = mutate(parent, 0, 0.5, mulberry32(8));
+    expect(same.layers[0].w).toEqual(parent.layers[0].w);
+  });
+});
+
+describe("crossover", () => {
+  it("only ever takes genes from one of the two parents", () => {
+    const a = createNetwork(shape, mulberry32(9));
+    const b = createNetwork(shape, mulberry32(10));
+    const child = crossover(a, b, mulberry32(11));
+    child.layers.forEach((layer, li) => {
+      layer.w.forEach((gene, k) => {
+        expect([a.layers[li].w[k], b.layers[li].w[k]]).toContain(gene);
+      });
+    });
+  });
+});
+
+describe("cloneNetwork", () => {
+  it("deep-copies so edits do not leak back", () => {
+    const net = createNetwork(shape, mulberry32(12));
+    const clone = cloneNetwork(net);
+    clone.layers[0].w[0] = 999;
+    expect(net.layers[0].w[0]).not.toBe(999);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/nn.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/nn.ts
@@ -1,0 +1,103 @@
+// A tiny fixed-topology MLP. The weights are the genome the genetic algorithm
+// evolves; there is no backprop here, only mutation and crossover.
+
+import { gaussian } from "./geometry";
+
+export interface Layer {
+  inSize: number;
+  outSize: number;
+  // Row-major weights, length outSize * inSize.
+  w: number[];
+  b: number[];
+}
+
+export interface Network {
+  layers: Layer[];
+}
+
+// [inputs, ...hidden, outputs]. Every layer uses tanh, so outputs land in
+// (-1, 1) ready to drive steering and throttle.
+export type Shape = number[];
+
+export function createNetwork(shape: Shape, rand: () => number): Network {
+  const layers: Layer[] = [];
+  for (let i = 0; i < shape.length - 1; i++) {
+    const inSize = shape[i];
+    const outSize = shape[i + 1];
+    const w: number[] = new Array(inSize * outSize);
+    const b: number[] = new Array(outSize);
+    for (let k = 0; k < w.length; k++) w[k] = rand() * 2 - 1;
+    for (let k = 0; k < b.length; k++) b[k] = rand() * 2 - 1;
+    layers.push({ inSize, outSize, w, b });
+  }
+  return { layers };
+}
+
+export function forward(net: Network, input: number[]): number[] {
+  let signal = input;
+  for (const layer of net.layers) {
+    const out = new Array(layer.outSize);
+    for (let j = 0; j < layer.outSize; j++) {
+      let sum = layer.b[j];
+      const row = j * layer.inSize;
+      for (let i = 0; i < layer.inSize; i++) {
+        sum += layer.w[row + i] * signal[i];
+      }
+      out[j] = Math.tanh(sum);
+    }
+    signal = out;
+  }
+  return signal;
+}
+
+export function cloneNetwork(net: Network): Network {
+  return {
+    layers: net.layers.map((l) => ({
+      inSize: l.inSize,
+      outSize: l.outSize,
+      w: l.w.slice(),
+      b: l.b.slice(),
+    })),
+  };
+}
+
+// Perturb each gene with probability `rate` by a gaussian step of scale
+// `strength`. Mutates a fresh clone so the parent is left untouched.
+export function mutate(
+  net: Network,
+  rate: number,
+  strength: number,
+  rand: () => number,
+): Network {
+  const child = cloneNetwork(net);
+  for (const layer of child.layers) {
+    for (let k = 0; k < layer.w.length; k++) {
+      if (rand() < rate) layer.w[k] += gaussian(rand) * strength;
+    }
+    for (let k = 0; k < layer.b.length; k++) {
+      if (rand() < rate) layer.b[k] += gaussian(rand) * strength;
+    }
+  }
+  return child;
+}
+
+// Uniform crossover: each gene is taken from one parent or the other at random.
+export function crossover(a: Network, b: Network, rand: () => number): Network {
+  const child = cloneNetwork(a);
+  for (let li = 0; li < child.layers.length; li++) {
+    const layer = child.layers[li];
+    const other = b.layers[li];
+    for (let k = 0; k < layer.w.length; k++) {
+      if (rand() < 0.5) layer.w[k] = other.w[k];
+    }
+    for (let k = 0; k < layer.b.length; k++) {
+      if (rand() < 0.5) layer.b[k] = other.b[k];
+    }
+  }
+  return child;
+}
+
+// Total number of tunable parameters, handy for display and tests.
+export function genomeLength(net: Network): number {
+  return net.layers.reduce((n, l) => n + l.w.length + l.b.length, 0);
+}

--- a/src/app/playgrounds/neuroevolution/_lib/optimum.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/optimum.test.ts
@@ -1,0 +1,26 @@
+import { LAPS_TO_FINISH } from "./car";
+import { mulberry32 } from "./geometry";
+import { idealLapTicks, idealRunTicks } from "./optimum";
+import { buildTrack } from "./track";
+
+const track = buildTrack({ width: 900, height: 600 }, mulberry32(1));
+
+describe("idealLapTicks", () => {
+  it("is a positive, finite tick count", () => {
+    const t = idealLapTicks(track);
+    expect(t).toBeGreaterThan(0);
+    expect(Number.isFinite(t)).toBe(true);
+  });
+
+  it("lands in a sane range (a handful of seconds per lap)", () => {
+    const seconds = idealLapTicks(track) / 60;
+    expect(seconds).toBeGreaterThan(3);
+    expect(seconds).toBeLessThan(15);
+  });
+});
+
+describe("idealRunTicks", () => {
+  it("is the lap estimate times the lap target", () => {
+    expect(idealRunTicks(track)).toBeCloseTo(idealLapTicks(track) * LAPS_TO_FINISH);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/optimum.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/optimum.ts
@@ -1,0 +1,71 @@
+// Estimate the fastest lap the car physics allow on a given track, using a
+// quasi-steady-state speed profile along the centre line:
+//   1. Each point has a corner-speed cap (turn radius grows with speed, so a
+//      tight corner caps speed at TURN_RATE x radius), widened by half the road
+//      since a real line uses the track's width to open corners up.
+//   2. Forward/backward passes then limit how fast the car can accelerate out
+//      of and brake into each corner.
+// It's an estimate: cars can shave a touch more by cutting the line tighter.
+
+import { ACCEL, BRAKE, LAPS_TO_FINISH, MAX_SPEED, TURN_RATE } from "./car";
+import type { Track } from "./track";
+import type { Vec } from "./geometry";
+
+// Radius of the circle through three points; Infinity if near-collinear.
+function radius(a: Vec, b: Vec, c: Vec): number {
+  const ab = Math.hypot(b.x - a.x, b.y - a.y);
+  const bc = Math.hypot(c.x - b.x, c.y - b.y);
+  const ca = Math.hypot(a.x - c.x, a.y - c.y);
+  const area = Math.abs((b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)) / 2;
+  if (area < 1e-6) return Infinity;
+  return (ab * bc * ca) / (4 * area);
+}
+
+export function idealLapTicks(track: Track): number {
+  const pts = track.centerline;
+  const n = pts.length;
+  if (n < 3) return 0;
+
+  const ds = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    ds[i] = Math.hypot(pts[j].x - pts[i].x, pts[j].y - pts[i].y);
+  }
+
+  // Corners open up by the full road width on an ideal line (enter wide, apex,
+  // exit wide), so the estimate stays an optimistic bound the cars approach.
+  const widen = track.trackWidth;
+  const v = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    const r = radius(pts[(i - 1 + n) % n], pts[i], pts[(i + 1) % n]) + widen;
+    v[i] = Math.min(MAX_SPEED, TURN_RATE * r);
+  }
+
+  // Relax accel (forward) and brake (backward) limits; a few wraps converge on
+  // a closed loop. v_next^2 = v^2 + 2*a*ds is the constant-accel kinematic step.
+  for (let pass = 0; pass < 4; pass++) {
+    for (let i = 0; i < n; i++) {
+      const j = (i + 1) % n;
+      const reach = Math.sqrt(v[i] * v[i] + 2 * ACCEL * ds[i]);
+      if (v[j] > reach) v[j] = reach;
+    }
+    for (let i = n - 1; i >= 0; i--) {
+      const j = (i + 1) % n;
+      const reach = Math.sqrt(v[j] * v[j] + 2 * BRAKE * ds[i]);
+      if (v[i] > reach) v[i] = reach;
+    }
+  }
+
+  let ticks = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const vAvg = (v[i] + v[j]) / 2;
+    if (vAvg > 0.01) ticks += ds[i] / vAvg;
+  }
+  return ticks;
+}
+
+// Ideal time (ticks) for a full finishing run of LAPS_TO_FINISH laps.
+export function idealRunTicks(track: Track): number {
+  return idealLapTicks(track) * LAPS_TO_FINISH;
+}

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -8,7 +8,7 @@ import type { World } from "./world";
 const KEY = "neuroevolution-world";
 // Bump when the saved shape (track/network layout/scoring/physics) changes, to
 // drop stale saves.
-const VERSION = 5;
+const VERSION = 6;
 
 interface Saved {
   version: number;

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -1,0 +1,68 @@
+// Persist the running simulation to localStorage so a refresh resumes the same
+// evolved population on the same track instead of starting from scratch.
+
+import type { Network } from "./nn";
+import type { Track } from "./track";
+import type { World } from "./world";
+
+const KEY = "neuroevolution-world";
+// Bump when the saved shape (track/network layout/scoring/physics) changes, to
+// drop stale saves.
+const VERSION = 5;
+
+interface Saved {
+  version: number;
+  track: Track;
+  nets: Network[];
+  generation: number;
+  bestEver: number;
+  bestTicks: number;
+  history: number[];
+  timeHistory: number[];
+}
+
+export function saveWorld(world: World): void {
+  try {
+    const payload: Saved = {
+      version: VERSION,
+      track: world.track,
+      nets: world.cars.map((c) => c.net),
+      generation: world.generation,
+      bestEver: world.bestEver,
+      bestTicks: world.bestTicks,
+      history: world.history,
+      timeHistory: world.timeHistory,
+    };
+    window.localStorage.setItem(KEY, JSON.stringify(payload));
+  } catch {
+    // Storage full or unavailable (private mode): keep running unsaved.
+  }
+}
+
+// Returns the saved state, or null if there is none / it's from an old version.
+export function loadWorld(): Saved | null {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Saved;
+    if (
+      parsed.version !== VERSION ||
+      !parsed.track ||
+      !Array.isArray(parsed.nets) ||
+      parsed.nets.length === 0
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearWorld(): void {
+  try {
+    window.localStorage.removeItem(KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/app/playgrounds/neuroevolution/_lib/render.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/render.ts
@@ -1,17 +1,22 @@
 // Canvas rendering for the simulation. Pure drawing: it reads the world and
-// paints, holding no state of its own.
+// paints, holding no state of its own. Tuned to sit inside the telemetry
+// console: dark asphalt, beveled kerbs, a blueprint infield, and a glowing
+// additive swarm of cars trailing light.
 
 import { SENSOR_ANGLES } from "./car";
 import type { Car } from "./car";
 import { leader, type World } from "./world";
 
-const BG = "#0d0d0d";
-const ROAD = "#191920";
-const WALL = "#4b5563";
-const START = "#34d399";
-const PACK = "rgba(56, 189, 248, 0.55)";
+const BG = "#080a0e";
+const GRID = "rgba(150, 180, 205, 0.05)";
+const ROAD = "#151b26";
+const KERB_DARK = "#05070a";
+const KERB_EDGE = "rgba(150, 180, 205, 0.5)";
+const START = "#35d6a0";
+const PACK = "rgba(69, 200, 216, 0.5)";
 const LEADER = "#f7c948";
-const SENSOR = "rgba(247, 201, 72, 0.28)";
+const DONE = "#35d6a0";
+const SENSOR = "rgba(247, 201, 72, 0.22)";
 
 export function drawWorld(
   ctx: CanvasRenderingContext2D,
@@ -19,8 +24,12 @@ export function drawWorld(
   showSensors: boolean,
 ): void {
   const { track } = world;
+  const w = track.width;
+  const h = track.height;
+
   ctx.fillStyle = BG;
-  ctx.fillRect(0, 0, track.width, track.height);
+  ctx.fillRect(0, 0, w, h);
+  drawGrid(ctx, w, h);
 
   // Road surface: outer loop with the inner loop punched out (even-odd).
   ctx.beginPath();
@@ -29,56 +38,111 @@ export function drawWorld(
   ctx.fillStyle = ROAD;
   ctx.fill("evenodd");
 
-  // Walls.
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = WALL;
-  ctx.beginPath();
-  traceLoop(ctx, track.outer);
-  ctx.stroke();
-  ctx.beginPath();
-  traceLoop(ctx, track.inner);
-  ctx.stroke();
+  // Kerbs: a dark casing with a crisp light edge on top, for a beveled rim.
+  ctx.lineJoin = "round";
+  for (const loop of [track.outer, track.inner]) {
+    ctx.beginPath();
+    traceLoop(ctx, loop);
+    ctx.lineWidth = 5;
+    ctx.strokeStyle = KERB_DARK;
+    ctx.stroke();
+    ctx.lineWidth = 1.75;
+    ctx.strokeStyle = KERB_EDGE;
+    ctx.stroke();
+  }
 
-  // Start / finish gate.
-  const g = track.gates[0];
-  ctx.strokeStyle = START;
-  ctx.lineWidth = 3;
-  ctx.beginPath();
-  ctx.moveTo(g.ax, g.ay);
-  ctx.lineTo(g.bx, g.by);
-  ctx.stroke();
+  drawStart(ctx, track.gates[0]);
 
   const lead = leader(world);
 
   // Finished cars, parked where they crossed the line.
-  ctx.fillStyle = START;
-  ctx.beginPath();
+  ctx.globalCompositeOperation = "lighter";
   for (const c of world.cars) {
-    if (c.done) traceCar(ctx, c, 8, 5, 4);
+    if (c.done) {
+      drawTrail(ctx, c, DONE);
+      fillCar(ctx, c, DONE, 8, 5, 4);
+    }
   }
-  ctx.fill();
 
-  // Pack of cars still driving, in one batched path.
-  ctx.fillStyle = PACK;
-  ctx.beginPath();
+  // The pack still driving, blended additively so density reads as brightness.
   for (const c of world.cars) {
-    if (c.alive && !c.done && c !== lead) traceCar(ctx, c, 6, 4, 3);
+    if (c.alive && !c.done && c !== lead) {
+      drawTrail(ctx, c, "rgba(69, 200, 216, 0.5)");
+      fillCar(ctx, c, PACK, 6, 4, 3);
+    }
   }
-  ctx.fill();
+  ctx.globalCompositeOperation = "source-over";
 
+  // Leader on top, with sensors and a warm glow.
   if (lead && lead.alive && !lead.done) {
     if (showSensors) drawSensors(ctx, lead);
-    ctx.fillStyle = LEADER;
-    ctx.beginPath();
-    traceCar(ctx, lead, 9, 5, 4);
-    ctx.fill();
+    ctx.globalCompositeOperation = "lighter";
+    drawTrail(ctx, lead, "rgba(247, 201, 72, 0.55)");
+    ctx.globalCompositeOperation = "source-over";
+    ctx.save();
+    ctx.shadowBlur = 10;
+    ctx.shadowColor = LEADER;
+    fillCar(ctx, lead, LEADER, 10, 6, 4.5);
+    ctx.restore();
   }
+
+  // Soft vignette for depth.
+  const vg = ctx.createRadialGradient(w / 2, h / 2, h * 0.35, w / 2, h / 2, h * 0.75);
+  vg.addColorStop(0, "rgba(0,0,0,0)");
+  vg.addColorStop(1, "rgba(0,0,0,0.35)");
+  ctx.fillStyle = vg;
+  ctx.fillRect(0, 0, w, h);
+}
+
+function drawGrid(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  ctx.strokeStyle = GRID;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let x = 0; x <= w; x += 45) {
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, h);
+  }
+  for (let y = 0; y <= h; y += 45) {
+    ctx.moveTo(0, y);
+    ctx.lineTo(w, y);
+  }
+  ctx.stroke();
 }
 
 function traceLoop(ctx: CanvasRenderingContext2D, pts: { x: number; y: number }[]) {
   ctx.moveTo(pts[0].x, pts[0].y);
   for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
   ctx.closePath();
+}
+
+// Start/finish: a bright dashed gate with a small direction chevron.
+function drawStart(
+  ctx: CanvasRenderingContext2D,
+  gate: { ax: number; ay: number; bx: number; by: number },
+) {
+  ctx.save();
+  ctx.strokeStyle = START;
+  ctx.lineWidth = 3;
+  ctx.setLineDash([4, 3]);
+  ctx.beginPath();
+  ctx.moveTo(gate.ax, gate.ay);
+  ctx.lineTo(gate.bx, gate.by);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function fillCar(
+  ctx: CanvasRenderingContext2D,
+  car: Car,
+  color: string,
+  front: number,
+  back: number,
+  halfBase: number,
+) {
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  traceCar(ctx, car, front, back, halfBase);
+  ctx.fill();
 }
 
 function traceCar(
@@ -96,6 +160,24 @@ function traceCar(
   ctx.lineTo(car.x - fx * back + px * halfBase, car.y - fy * back + py * halfBase);
   ctx.lineTo(car.x - fx * back - px * halfBase, car.y - fy * back - py * halfBase);
   ctx.closePath();
+}
+
+// A short comet tail behind the car, fading out, length scaled by speed.
+function drawTrail(ctx: CanvasRenderingContext2D, car: Car, color: string) {
+  const len = Math.min(car.speed * 5, 42);
+  if (len < 3) return;
+  const bx = car.x - Math.cos(car.angle) * len;
+  const by = car.y - Math.sin(car.angle) * len;
+  const grad = ctx.createLinearGradient(car.x, car.y, bx, by);
+  grad.addColorStop(0, color);
+  grad.addColorStop(1, "transparent");
+  ctx.strokeStyle = grad;
+  ctx.lineWidth = 2;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(car.x, car.y);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
 }
 
 function drawSensors(ctx: CanvasRenderingContext2D, car: Car) {

--- a/src/app/playgrounds/neuroevolution/_lib/render.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/render.ts
@@ -1,0 +1,118 @@
+// Canvas rendering for the simulation. Pure drawing: it reads the world and
+// paints, holding no state of its own.
+
+import { SENSOR_ANGLES } from "./car";
+import type { Car } from "./car";
+import { leader, type World } from "./world";
+
+const BG = "#0d0d0d";
+const ROAD = "#191920";
+const WALL = "#4b5563";
+const START = "#34d399";
+const PACK = "rgba(56, 189, 248, 0.55)";
+const LEADER = "#f7c948";
+const SENSOR = "rgba(247, 201, 72, 0.28)";
+
+export function drawWorld(
+  ctx: CanvasRenderingContext2D,
+  world: World,
+  showSensors: boolean,
+): void {
+  const { track } = world;
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, track.width, track.height);
+
+  // Road surface: outer loop with the inner loop punched out (even-odd).
+  ctx.beginPath();
+  traceLoop(ctx, track.outer);
+  traceLoop(ctx, track.inner);
+  ctx.fillStyle = ROAD;
+  ctx.fill("evenodd");
+
+  // Walls.
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = WALL;
+  ctx.beginPath();
+  traceLoop(ctx, track.outer);
+  ctx.stroke();
+  ctx.beginPath();
+  traceLoop(ctx, track.inner);
+  ctx.stroke();
+
+  // Start / finish gate.
+  const g = track.gates[0];
+  ctx.strokeStyle = START;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(g.ax, g.ay);
+  ctx.lineTo(g.bx, g.by);
+  ctx.stroke();
+
+  const lead = leader(world);
+
+  // Finished cars, parked where they crossed the line.
+  ctx.fillStyle = START;
+  ctx.beginPath();
+  for (const c of world.cars) {
+    if (c.done) traceCar(ctx, c, 8, 5, 4);
+  }
+  ctx.fill();
+
+  // Pack of cars still driving, in one batched path.
+  ctx.fillStyle = PACK;
+  ctx.beginPath();
+  for (const c of world.cars) {
+    if (c.alive && !c.done && c !== lead) traceCar(ctx, c, 6, 4, 3);
+  }
+  ctx.fill();
+
+  if (lead && lead.alive && !lead.done) {
+    if (showSensors) drawSensors(ctx, lead);
+    ctx.fillStyle = LEADER;
+    ctx.beginPath();
+    traceCar(ctx, lead, 9, 5, 4);
+    ctx.fill();
+  }
+}
+
+function traceLoop(ctx: CanvasRenderingContext2D, pts: { x: number; y: number }[]) {
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  ctx.closePath();
+}
+
+function traceCar(
+  ctx: CanvasRenderingContext2D,
+  car: Car,
+  front: number,
+  back: number,
+  halfBase: number,
+) {
+  const fx = Math.cos(car.angle);
+  const fy = Math.sin(car.angle);
+  const px = -fy;
+  const py = fx;
+  ctx.moveTo(car.x + fx * front, car.y + fy * front);
+  ctx.lineTo(car.x - fx * back + px * halfBase, car.y - fy * back + py * halfBase);
+  ctx.lineTo(car.x - fx * back - px * halfBase, car.y - fy * back - py * halfBase);
+  ctx.closePath();
+}
+
+function drawSensors(ctx: CanvasRenderingContext2D, car: Car) {
+  ctx.strokeStyle = SENSOR;
+  ctx.fillStyle = SENSOR;
+  ctx.lineWidth = 1;
+  for (let s = 0; s < SENSOR_ANGLES.length; s++) {
+    const a = car.angle + SENSOR_ANGLES[s];
+    const d = car.sensors[s];
+    const ex = car.x + Math.cos(a) * d;
+    const ey = car.y + Math.sin(a) * d;
+    ctx.beginPath();
+    ctx.moveTo(car.x, car.y);
+    ctx.lineTo(ex, ey);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(ex, ey, 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}

--- a/src/app/playgrounds/neuroevolution/_lib/track.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/track.test.ts
@@ -1,0 +1,43 @@
+import { mulberry32 } from "./geometry";
+import { buildTrack } from "./track";
+
+const cfg = { width: 800, height: 600, points: 48 };
+
+describe("buildTrack", () => {
+  it("produces matching centreline, walls and gates counts", () => {
+    const t = buildTrack(cfg, mulberry32(1));
+    expect(t.centerline).toHaveLength(48);
+    expect(t.inner).toHaveLength(48);
+    expect(t.outer).toHaveLength(48);
+    expect(t.walls).toHaveLength(96); // inner + outer per segment
+    expect(t.gates).toHaveLength(48);
+  });
+
+  it("numbers gates in order", () => {
+    const t = buildTrack(cfg, mulberry32(2));
+    t.gates.forEach((g, i) => expect(g.index).toBe(i));
+  });
+
+  it("keeps the outer wall further from centre than the inner wall", () => {
+    const t = buildTrack(cfg, mulberry32(3));
+    const cx = cfg.width / 2;
+    const cy = cfg.height / 2;
+    for (let i = 0; i < t.centerline.length; i++) {
+      const inD = Math.hypot(t.inner[i].x - cx, t.inner[i].y - cy);
+      const outD = Math.hypot(t.outer[i].x - cx, t.outer[i].y - cy);
+      expect(outD).toBeGreaterThan(inD);
+    }
+  });
+
+  it("starts on the first gate", () => {
+    const t = buildTrack(cfg, mulberry32(4));
+    expect(t.start.x).toBeCloseTo(t.centerline[0].x);
+    expect(t.start.y).toBeCloseTo(t.centerline[0].y);
+  });
+
+  it("varies with the seed", () => {
+    const a = buildTrack(cfg, mulberry32(5));
+    const b = buildTrack(cfg, mulberry32(6));
+    expect(a.centerline).not.toEqual(b.centerline);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/track.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/track.ts
@@ -1,0 +1,187 @@
+// A procedural closed race track. A wavy ellipse forms the centreline; we
+// offset it by half the track width to get the inner and outer walls, and drop
+// ordered gates across the track for measuring progress.
+
+import { segmentsIntersect, type Vec } from "./geometry";
+
+interface Harmonic {
+  f: number;
+  a: number;
+  p: number;
+}
+
+export interface Wall {
+  ax: number;
+  ay: number;
+  bx: number;
+  by: number;
+}
+
+export interface Gate extends Wall {
+  index: number;
+}
+
+export interface Track {
+  width: number;
+  height: number;
+  trackWidth: number;
+  // Average spacing between gates; used to shape the fitness gradient.
+  gateSpacing: number;
+  centerline: Vec[];
+  inner: Vec[];
+  outer: Vec[];
+  walls: Wall[];
+  gates: Gate[];
+  start: { x: number; y: number; angle: number };
+}
+
+export interface TrackConfig {
+  width: number;
+  height: number;
+  points?: number;
+}
+
+const TAU = Math.PI * 2;
+
+export function buildTrack(config: TrackConfig, rand: () => number): Track {
+  const { width, height } = config;
+  const n = config.points ?? 72;
+  const cx = width / 2;
+  const cy = height / 2;
+  const rx = width * 0.33;
+  const ry = height * 0.32;
+  // A narrow road: precision matters and corners can be tighter before the
+  // offset walls would fold.
+  const trackWidth = Math.min(width, height) * 0.068;
+  const half = trackWidth / 2;
+
+  // Three seeded harmonics stacked on a radial function give real corners and
+  // chicanes rather than a lazy oval, while a radial shape stays simple (never
+  // self-intersecting). More lobes plus a narrow road make a technical circuit
+  // that takes real skill (and many generations) to drive quickly.
+  const base = 3 + Math.floor(rand() * 2); // 3 or 4
+  const harmonics: Harmonic[] = [
+    { f: base, a: 0.15 + rand() * 0.07, p: rand() * TAU },
+    { f: base + 2 + Math.floor(rand() * 2), a: 0.1 + rand() * 0.06, p: rand() * TAU },
+    { f: base + 4 + Math.floor(rand() * 3), a: 0.05 + rand() * 0.04, p: rand() * TAU },
+  ];
+
+  // Sharp corners can fold the offset walls over themselves. Soften the wobble
+  // and rebuild until both walls are clean, so no seed yields a broken track.
+  let geo = geometry(cx, cy, rx, ry, half, n, harmonics, 1);
+  for (let tries = 0; tries < 8 && wallsPinch(geo.inner, geo.outer); tries++) {
+    geo = geometry(cx, cy, rx, ry, half, n, harmonics, 0.8 ** (tries + 1));
+  }
+  const { centerline, inner, outer } = geo;
+
+  const walls: Wall[] = [];
+  const gates: Gate[] = [];
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    walls.push({ ax: inner[i].x, ay: inner[i].y, bx: inner[j].x, by: inner[j].y });
+    walls.push({ ax: outer[i].x, ay: outer[i].y, bx: outer[j].x, by: outer[j].y });
+    gates.push({
+      ax: inner[i].x,
+      ay: inner[i].y,
+      bx: outer[i].x,
+      by: outer[i].y,
+      index: i,
+    });
+  }
+
+  // Start on the first gate, facing the next one.
+  const startDir = Math.atan2(
+    centerline[1].y - centerline[0].y,
+    centerline[1].x - centerline[0].x,
+  );
+
+  let perimeter = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    perimeter += Math.hypot(
+      centerline[j].x - centerline[i].x,
+      centerline[j].y - centerline[i].y,
+    );
+  }
+
+  return {
+    width,
+    height,
+    trackWidth,
+    gateSpacing: perimeter / n,
+    centerline,
+    inner,
+    outer,
+    walls,
+    gates,
+    start: { x: centerline[0].x, y: centerline[0].y, angle: startDir },
+  };
+}
+
+// Centreline + offset walls at a given wobble scale (1 = full strength).
+function geometry(
+  cx: number,
+  cy: number,
+  rx: number,
+  ry: number,
+  half: number,
+  n: number,
+  harmonics: Harmonic[],
+  scale: number,
+): { centerline: Vec[]; inner: Vec[]; outer: Vec[] } {
+  const centerline: Vec[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * TAU;
+    let rmul = 1;
+    for (const h of harmonics) rmul += h.a * scale * Math.sin(h.f * a + h.p);
+    centerline.push({
+      x: cx + Math.cos(a) * rx * rmul,
+      y: cy + Math.sin(a) * ry * rmul,
+    });
+  }
+
+  const inner: Vec[] = [];
+  const outer: Vec[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = centerline[(i - 1 + n) % n];
+    const next = centerline[(i + 1) % n];
+    const tx = next.x - prev.x;
+    const ty = next.y - prev.y;
+    const tl = Math.hypot(tx, ty) || 1;
+    // Normal to the tangent, flipped so it always points away from centre.
+    let nx = -ty / tl;
+    let ny = tx / tl;
+    const rcx = centerline[i].x - cx;
+    const rcy = centerline[i].y - cy;
+    if (nx * rcx + ny * rcy < 0) {
+      nx = -nx;
+      ny = -ny;
+    }
+    outer.push({ x: centerline[i].x + nx * half, y: centerline[i].y + ny * half });
+    inner.push({ x: centerline[i].x - nx * half, y: centerline[i].y - ny * half });
+  }
+
+  return { centerline, inner, outer };
+}
+
+// True if either wall loop crosses itself (a folded, impassable corner).
+function wallsPinch(inner: Vec[], outer: Vec[]): boolean {
+  return loopSelfIntersects(inner) || loopSelfIntersects(outer);
+}
+
+function loopSelfIntersects(loop: Vec[]): boolean {
+  const n = loop.length;
+  for (let i = 0; i < n; i++) {
+    const a1 = loop[i];
+    const a2 = loop[(i + 1) % n];
+    for (let j = i + 2; j < n; j++) {
+      if (i === 0 && j === n - 1) continue; // adjacent across the wrap
+      const b1 = loop[j];
+      const b2 = loop[(j + 1) % n];
+      if (segmentsIntersect(a1.x, a1.y, a2.x, a2.y, b1.x, b1.y, b2.x, b2.y)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -1,0 +1,68 @@
+import { mulberry32 } from "./geometry";
+import {
+  DEFAULT_CONFIG,
+  activeCount,
+  createWorld,
+  leader,
+  stepWorld,
+} from "./world";
+
+const viewport = { width: 800, height: 600 };
+const config = { ...DEFAULT_CONFIG, populationSize: 12, maxSteps: 50 };
+
+describe("createWorld", () => {
+  it("builds a full population on a track at generation 1", () => {
+    const w = createWorld(config, viewport, mulberry32(1));
+    expect(w.cars).toHaveLength(12);
+    expect(w.generation).toBe(1);
+    expect(w.step).toBe(0);
+    expect(w.track.gates.length).toBeGreaterThan(0);
+    expect(activeCount(w)).toBe(12);
+  });
+});
+
+describe("stepWorld", () => {
+  it("advances the step counter while cars survive", () => {
+    const w = createWorld(config, viewport, mulberry32(2));
+    stepWorld(w, config, mulberry32(3));
+    expect(w.step).toBe(1);
+  });
+
+  it("rolls to the next generation and resets with a fresh population", () => {
+    const w = createWorld(config, viewport, mulberry32(4));
+    const rand = mulberry32(5);
+    // A generation ends when no car is still driving or at the step cap,
+    // whichever comes first; step until it turns over.
+    let guard = 0;
+    while (w.generation === 1 && guard < 5000) {
+      stepWorld(w, config, rand);
+      guard++;
+    }
+    expect(w.generation).toBe(2);
+    expect(w.step).toBe(0);
+    expect(w.history).toHaveLength(1);
+    expect(w.cars).toHaveLength(12);
+    expect(activeCount(w)).toBe(12); // fresh population
+  });
+
+  it("ends the generation early once every car has crashed", () => {
+    const w = createWorld(config, viewport, mulberry32(6));
+    const rand = mulberry32(7);
+    // Kill everyone manually, then a single step should trigger evolution.
+    w.cars.forEach((c) => (c.alive = false));
+    stepWorld(w, config, rand);
+    expect(w.generation).toBe(2);
+    expect(w.history).toHaveLength(1);
+  });
+});
+
+describe("leader", () => {
+  it("prefers a living car over a fitter dead one", () => {
+    const w = createWorld(config, viewport, mulberry32(8));
+    w.cars[0].alive = false;
+    w.cars[0].fitness = 100;
+    w.cars[1].alive = true;
+    w.cars[1].fitness = 1;
+    expect(leader(w)).toBe(w.cars[1]);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -1,0 +1,170 @@
+// Ties the pieces together: a track, a population of cars, and the generation
+// lifecycle. Kept free of React and canvas so the loop can be unit tested.
+
+import {
+  BRAIN_SHAPE,
+  FINISH_TIME_BUDGET,
+  createCar,
+  stepCar,
+  type Car,
+} from "./car";
+import {
+  computeStats,
+  evolve,
+  type EvolveConfig,
+  type Scored,
+} from "./genetic";
+import { createNetwork } from "./nn";
+import { buildTrack, type Track } from "./track";
+
+export interface SimConfig extends EvolveConfig {
+  // Hard cap on ticks per generation, so a car that laps forever still hands
+  // over to the next generation.
+  maxSteps: number;
+  // Domain randomization: when true, a fresh track is generated every
+  // generation, so the population is selected for driving in general rather
+  // than for one specific layout.
+  varyTrack: boolean;
+}
+
+export const DEFAULT_CONFIG: SimConfig = {
+  populationSize: 50,
+  eliteCount: 4,
+  tournamentSize: 5,
+  mutationRate: 0.12,
+  mutationStrength: 0.4,
+  maxSteps: FINISH_TIME_BUDGET,
+  varyTrack: false,
+};
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export interface World {
+  track: Track;
+  cars: Car[];
+  generation: number;
+  step: number;
+  bestEver: number;
+  // Fewest ticks any car has ever taken to finish (0 = nobody has yet).
+  bestTicks: number;
+  // Best fitness of each completed generation.
+  history: number[];
+  // Best finish time (ticks) of each generation, 0 if none finished. Drives the
+  // history chart, since it's the metric that keeps meaningfully improving.
+  timeHistory: number[];
+}
+
+export function createWorld(
+  config: SimConfig,
+  viewport: Viewport,
+  rand: () => number,
+): World {
+  const track = buildTrack(viewport, rand);
+  const cars: Car[] = [];
+  for (let i = 0; i < config.populationSize; i++) {
+    cars.push(createCar(createNetwork(BRAIN_SHAPE, rand), track));
+  }
+  return {
+    track,
+    cars,
+    generation: 1,
+    step: 0,
+    bestEver: 0,
+    bestTicks: 0,
+    history: [],
+    timeHistory: [],
+  };
+}
+
+// A car still driving: alive and not yet finished.
+function isActive(c: Car): boolean {
+  return c.alive && !c.done;
+}
+
+// The car worth highlighting: one still driving with the highest fitness, or
+// the best finisher/wreck if the field is spent.
+export function leader(world: World): Car | null {
+  let best: Car | null = null;
+  for (const c of world.cars) {
+    if (!best) {
+      best = c;
+      continue;
+    }
+    const better =
+      (isActive(c) && !isActive(best)) ||
+      (isActive(c) === isActive(best) && c.fitness > best.fitness);
+    if (better) best = c;
+  }
+  return best;
+}
+
+export function activeCount(world: World): number {
+  let n = 0;
+  for (const c of world.cars) if (isActive(c)) n++;
+  return n;
+}
+
+// Fewest finish ticks among cars that finished this generation (0 if none).
+export function bestFinishTicks(world: World): number {
+  let best = 0;
+  for (const c of world.cars) {
+    if (c.done && (best === 0 || c.finishTicks < best)) best = c.finishTicks;
+  }
+  return best;
+}
+
+// Advance one tick. When no car is still driving (all finished or crashed), or
+// the safety cap is hit, breed the next generation in place.
+export function stepWorld(
+  world: World,
+  config: SimConfig,
+  rand: () => number,
+): void {
+  let anyActive = false;
+  for (const car of world.cars) {
+    stepCar(car, world.track);
+    if (isActive(car)) anyActive = true;
+  }
+  world.step += 1;
+
+  if (!anyActive || world.step >= config.maxSteps) {
+    endGeneration(world, config, rand);
+  }
+}
+
+function endGeneration(
+  world: World,
+  config: SimConfig,
+  rand: () => number,
+): void {
+  const scored: Scored[] = world.cars.map((c) => ({
+    net: c.net,
+    fitness: c.fitness,
+  }));
+  const stats = computeStats(scored);
+  world.history.push(stats.best);
+  if (stats.best > world.bestEver) world.bestEver = stats.best;
+
+  const genTicks = bestFinishTicks(world);
+  world.timeHistory.push(genTicks);
+  if (genTicks > 0 && (world.bestTicks === 0 || genTicks < world.bestTicks)) {
+    world.bestTicks = genTicks;
+  }
+
+  const nets = evolve(scored, config, rand);
+  // Domain randomization reshuffles the course each generation; the fastest-run
+  // record only means something on a fixed track, so reset it when varying.
+  if (config.varyTrack) {
+    world.track = buildTrack(
+      { width: world.track.width, height: world.track.height },
+      rand,
+    );
+    world.bestTicks = 0;
+  }
+  world.cars = nets.map((net) => createCar(net, world.track));
+  world.generation += 1;
+  world.step = 0;
+}

--- a/src/app/playgrounds/neuroevolution/opengraph-image.tsx
+++ b/src/app/playgrounds/neuroevolution/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { createOgImage } from "../_og/createOgImage";
+
+export const runtime = "edge";
+export const alt = "Neuroevolution";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default createOgImage(
+  "Neuroevolution",
+  "Cars grow neural-net brains via a genetic algorithm, learning to drive a track live.",
+);

--- a/src/app/playgrounds/neuroevolution/page.tsx
+++ b/src/app/playgrounds/neuroevolution/page.tsx
@@ -1,0 +1,17 @@
+import { Neuroevolution } from "./_components/Neuroevolution";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Neuroevolution | Playground",
+  description:
+    "A population of cars grow neural-net brains via a genetic algorithm, learning to drive a track live. No training data, just survival of the fittest.",
+  openGraph: {
+    title: "Neuroevolution",
+    description:
+      "A population of cars grow neural-net brains via a genetic algorithm, learning to drive a track live. No training data, just survival of the fittest.",
+  },
+};
+
+export default function NeuroevolutionPage() {
+  return <Neuroevolution />;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,6 +62,119 @@
   100% { transform: scale(1) rotate(-3deg); }
 }
 
+/* --- Neuroevolution: telemetry console --- */
+
+.neuro-console {
+  --ink: #07090c;
+  --panel: #0d1016;
+  --line: rgba(150, 180, 205, 0.14);
+  --line-2: rgba(150, 180, 205, 0.28);
+  --text: #e9eff3;
+  --muted: rgba(233, 239, 243, 0.44);
+  --amber: #f7c948;
+  --cyan: #45c8d8;
+  --red: #ff5140;
+  --mint: #35d6a0;
+}
+
+@utility font-telemetry {
+  font-family: var(--font-neuro-display), "Chakra Petch", ui-sans-serif, system-ui,
+    sans-serif;
+}
+
+@utility font-readout {
+  font-family: var(--font-neuro-mono), ui-monospace, "SFMono-Regular", monospace;
+}
+
+/* Panels boot in on load, staggered via inline animation-delay. */
+@keyframes neuro-boot {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.neuro-boot {
+  opacity: 0;
+  animation: neuro-boot 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+/* A steady instrument blink for status LEDs. */
+@keyframes neuro-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0.2;
+  }
+}
+
+/* A soft glow pulse for "recording"/live markers. */
+@keyframes neuro-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 currentColor;
+  }
+  50% {
+    opacity: 0.55;
+    box-shadow: 0 0 7px 1px currentColor;
+  }
+}
+
+/* One-time scanline sweep across the console on load. */
+@keyframes neuro-sweep {
+  0% {
+    transform: translateY(-10%);
+    opacity: 0;
+  }
+  8% {
+    opacity: 0.5;
+  }
+  100% {
+    transform: translateY(2200%);
+    opacity: 0;
+  }
+}
+
+/* Custom instrument slider. Fill driven by --pct set inline. */
+.neuro-range {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--amber) var(--pct, 0%),
+    rgba(150, 180, 205, 0.18) var(--pct, 0%)
+  );
+  cursor: pointer;
+}
+
+.neuro-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 16px;
+  background: var(--amber);
+  border: 1px solid #000;
+  clip-path: polygon(50% 0, 100% 30%, 100% 100%, 0 100%, 0 30%);
+}
+
+.neuro-range::-moz-range-thumb {
+  width: 10px;
+  height: 16px;
+  border: 1px solid #000;
+  background: var(--amber);
+  clip-path: polygon(50% 0, 100% 30%, 100% 100%, 0 100%, 0 30%);
+}
+
 /* --- Lottery: "The Midnight Draw" --- */
 
 @utility font-marquee {


### PR DESCRIPTION
## What

A new AI playground: a population of cars, each steered by its own small neural network, learns to drive a procedural track via a genetic algorithm. No backpropagation and no training data, cars are scored on how they drive, the fittest are bred (uniform crossover + Gaussian mutation), and each generation improves.

- **Goal is a clean 3-lap run, as fast as possible.** Generations end when the field is spent and get quicker as the cars improve; the headline metric is a lap time that keeps dropping toward the physics floor.
- **A technical challenge, not a solved one.** Turn radius grows with speed and braking bites harder than the throttle, so the winning line is "flat out, brake hard, apex, accelerate out." The car is deliberately overpowered for the narrow, many-cornered tracks, so mastery takes dozens of generations rather than snapping to optimal.
- **Domain-randomization toggle** ("Vary track"): a fresh track every generation, selecting for cars that generalise rather than memorise one layout.
- **Persistence:** progress saves to localStorage and a refresh resumes it. "New track" keeps the evolved brains (watch them handle a new course); "Fresh start" wipes them.
- **Visualisation:** canvas render of the pack with the leader's sensors, a live diagram of the leader's network (edges tinted by weight sign/magnitude), and a best-fitness-per-generation sparkline.

The simulation core is split into pure, unit-tested modules (geometry, neural net, procedural track, car physics, genetic algorithm, world lifecycle) with a thin canvas/React layer on top.

## Why

The repo's other AI demos (Connect 4, Tetris AI) are gradient-based/deep-RL agents playing games. This adds a different flavour of machine learning, evolutionary optimisation, and makes the learning process itself the thing you watch.

## Risk / testing

Self-contained new route; only shared change is the homepage registry entry.

- 137 tests pass (40 new, covering geometry, nn, track, car, genetic, world)
- \`tsc --noEmit\` clean; lint clean for the new code (2 pre-existing warnings elsewhere untouched)
- production build green
- Verified with throwaway headless harnesses (since removed): tracks are always geometrically valid (no folded corners), cars learn to finish and then keep getting faster over many generations, champions generalise to unseen tracks well above chance, and the difficulty tuning makes convergence gradual rather than instant.

Not verified by CI (no browser in the dev environment): the actual on-canvas feel and the network/sparkline rendering. Worth an eyeball via \`pnpm dev\` at \`/playgrounds/neuroevolution\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)