### PR TITLE
feat: champion selection for neuroevolution (record-holder, immigrants, generalist)

### DIFF
--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { mulberry32 } from "../../_lib/geometry";
 import type { Network } from "../../_lib/nn";
 import { clearWorld, loadWorld, saveWorld } from "../../_lib/persistence";
-import { LAPS_TO_FINISH, createCar, stepCar, type Car } from "../../_lib/car";
+import {
+  FINISH_TIME_BUDGET,
+  LAPS_TO_FINISH,
+  createCar,
+  stepCar,
+  type Car,
+} from "../../_lib/car";
 import { buildTrack } from "../../_lib/track";
 import { drawWorld } from "../../_lib/render";
 import { idealRunTicks } from "../../_lib/optimum";
@@ -32,6 +38,8 @@ const HUD_EVERY = 6;
 const TICKS_PER_SEC = 60;
 
 type Mode = "evolve" | "solo";
+// Which champion the spotlight (solo / export / breed) acts on.
+type Champion = "track" | "general";
 
 interface Stats {
   mode: Mode;
@@ -41,6 +49,9 @@ interface Stats {
   genTicks: number;
   bestTicks: number;
   idealTicks: number;
+  // Generalist champion's worst-case time over the held-out battery (0 until it
+  // finishes all of them).
+  generalTicks: number;
   runTimes: number[];
   leaderNet: Network | null;
   // Solo-mode fields.
@@ -57,12 +68,19 @@ const EMPTY_STATS: Stats = {
   genTicks: 0,
   bestTicks: 0,
   idealTicks: 0,
+  generalTicks: 0,
   runTimes: [],
   leaderNet: null,
   soloLaps: 0,
   soloRunTicks: 0,
   soloBestTicks: 0,
 };
+
+// The generalist "finishes all N" worst-case time, or 0 if it can't yet clear
+// every battery track.
+function generalistTicks(score: number): number {
+  return score > 0 && score < FINISH_TIME_BUDGET ? score : 0;
+}
 
 // Seconds string for a tick count ("—" when there's nothing yet).
 function secs(ticks: number): string {
@@ -84,6 +102,7 @@ export function Neuroevolution() {
   // Solo mode: race one champion brain on a loop, no evolution.
   const modeRef = useRef<Mode>("evolve");
   const championRef = useRef<Network | null>(null);
+  const championKindRef = useRef<Champion>("track");
   const soloCarRef = useRef<Car | null>(null);
   const soloBestRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -95,6 +114,7 @@ export function Neuroevolution() {
   const [mutationRate, setMutationRate] = useState(DEFAULT_CONFIG.mutationRate);
   const [varyTrack, setVaryTrack] = useState(DEFAULT_CONFIG.varyTrack);
   const [mode, setMode] = useState<Mode>("evolve");
+  const [championKind, setChampionKind] = useState<Champion>("track");
   const [ioMsg, setIoMsg] = useState("");
 
   const flush = useCallback(() => {
@@ -107,6 +127,7 @@ export function Neuroevolution() {
         ...prev,
         mode: "solo",
         idealTicks: idealRunTicks(w.track),
+        generalTicks: generalistTicks(w.generalScore),
         leaderNet: championRef.current,
         soloLaps: car ? Math.min(LAPS_TO_FINISH, Math.floor(car.gatesPassed / gateCount)) : 0,
         soloRunTicks: car ? car.ticks : 0,
@@ -129,6 +150,7 @@ export function Neuroevolution() {
       genTicks,
       bestTicks,
       idealTicks: idealRunTicks(w.track),
+      generalTicks: generalistTicks(w.generalScore),
       runTimes: w.timeHistory.map((t) => t / 60),
       leaderNet: lead ? lead.net : null,
     }));
@@ -141,6 +163,9 @@ export function Neuroevolution() {
     if (championRef.current && modeRef.current === "solo") return championRef.current;
     const w = worldRef.current;
     if (!w) return null;
+    if (championKindRef.current === "general") {
+      return w.generalNet ?? w.bestNet ?? leader(w)?.net ?? null;
+    }
     return w.bestNet ?? leader(w)?.net ?? w.cars[0]?.net ?? null;
   }, []);
 
@@ -163,6 +188,10 @@ export function Neuroevolution() {
           bestEver: 0,
           bestTicks: 0,
           bestNet: null,
+          // Track record is track-specific and resets; the generalist carries
+          // over (it's track-independent).
+          generalScore: prev.generalScore,
+          generalNet: prev.generalNet,
           stall: 0,
           history: [],
           timeHistory: [],
@@ -200,6 +229,8 @@ export function Neuroevolution() {
         bestEver: saved.bestEver,
         bestTicks: saved.bestTicks,
         bestNet: saved.bestNet ?? null,
+        generalScore: saved.generalScore ?? 0,
+        generalNet: saved.generalNet ?? null,
         stall: 0,
         history: saved.history,
         timeHistory: saved.timeHistory ?? [],
@@ -296,6 +327,18 @@ export function Neuroevolution() {
     [flush, spotlightNet],
   );
 
+  // Choose which champion the spotlight (solo / export / breed) targets. If
+  // already racing solo, re-race the newly chosen champion.
+  const pickChampion = (kind: Champion) => {
+    championKindRef.current = kind;
+    setChampionKind(kind);
+    if (modeRef.current === "solo") {
+      const w = worldRef.current;
+      const net = kind === "general" ? w?.generalNet : w?.bestNet;
+      if (net) enterSolo(net);
+    }
+  };
+
   const toggleSolo = () => {
     if (modeRef.current === "solo") {
       modeRef.current = "evolve";
@@ -360,6 +403,8 @@ export function Neuroevolution() {
       bestEver: 0,
       bestTicks: 0,
       bestNet: null,
+      generalScore: 0,
+      generalNet: null,
       stall: 0,
       history: [],
       timeHistory: [],
@@ -529,6 +574,25 @@ export function Neuroevolution() {
                   {deltaS !== null && <DeltaChip delta={deltaS} />}
                 </div>
               </div>
+              {/* Generalist: best across the held-out battery (all tracks). */}
+              <div className="flex items-center justify-between border-t border-[var(--line)] px-3 py-2.5">
+                <span
+                  className="font-readout text-[9px] uppercase tracking-[0.25em] text-[var(--muted)]"
+                  title="Best worst-case time across 5 held-out tracks the population never trains on — turn on Vary track to grow this"
+                >
+                  Generalist · worst of 5
+                </span>
+                <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--cyan)]">
+                  {stats.generalTicks > 0 ? (
+                    <>
+                      {(stats.generalTicks / TICKS_PER_SEC).toFixed(1)}
+                      <span className="ml-0.5 text-[10px] text-[var(--muted)]">s</span>
+                    </>
+                  ) : (
+                    <span className="text-[var(--muted)]">—</span>
+                  )}
+                </span>
+              </div>
             </Panel>
 
             <Panel
@@ -669,10 +733,38 @@ export function Neuroevolution() {
           style={{ animationDelay: "380ms" }}
         >
           <div className="flex flex-wrap items-center gap-2">
+            <FieldLabel>Spotlight</FieldLabel>
+            <div className="flex overflow-hidden rounded-sm border border-[var(--line-2)]">
+              {(
+                [
+                  ["track", "Track"],
+                  ["general", "All-tracks"],
+                ] as const
+              ).map(([kind, label]) => (
+                <button
+                  key={kind}
+                  type="button"
+                  onClick={() => pickChampion(kind)}
+                  title={
+                    kind === "track"
+                      ? "The fastest brain on the current track (a specialist)"
+                      : "The brain that generalises best across held-out tracks"
+                  }
+                  className={`px-2.5 py-1.5 font-readout text-[10px] uppercase tracking-[0.18em] transition-colors ${
+                    championKind === kind
+                      ? "bg-[var(--cyan)]/20 text-[var(--cyan)]"
+                      : "text-[var(--muted)] hover:text-[var(--text)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div className="mx-1 h-5 w-px bg-[var(--line)]" />
             <DeckButton
               onClick={toggleSolo}
               tone={solo ? "amber" : "line"}
-              title="Race just the best brain, on its own, looping"
+              title="Race the spotlighted champion on its own, looping"
             >
               {solo ? "Back to evolving" : "Race solo"}
             </DeckButton>

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -134,13 +134,14 @@ export function Neuroevolution() {
     }));
   }, []);
 
-  // The brain currently in the spotlight: the champion in solo, else the
-  // fittest of the population.
+  // The brain to spotlight/export: the champion being raced in solo, else the
+  // record-holder (best finish so far), falling back to the current leader
+  // before anyone has finished.
   const spotlightNet = useCallback((): Network | null => {
     if (championRef.current && modeRef.current === "solo") return championRef.current;
     const w = worldRef.current;
     if (!w) return null;
-    return leader(w)?.net ?? w.cars[0]?.net ?? null;
+    return w.bestNet ?? leader(w)?.net ?? w.cars[0]?.net ?? null;
   }, []);
 
   // Start a new track. keepBrains carries the current population over (watch
@@ -161,6 +162,7 @@ export function Neuroevolution() {
           step: 0,
           bestEver: 0,
           bestTicks: 0,
+          bestNet: null,
           history: [],
           timeHistory: [],
         };
@@ -196,6 +198,7 @@ export function Neuroevolution() {
         step: 0,
         bestEver: saved.bestEver,
         bestTicks: saved.bestTicks,
+        bestNet: saved.bestNet ?? null,
         history: saved.history,
         timeHistory: saved.timeHistory ?? [],
       };
@@ -354,6 +357,7 @@ export function Neuroevolution() {
       step: 0,
       bestEver: 0,
       bestTicks: 0,
+      bestNet: null,
       history: [],
       timeHistory: [],
     };

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -163,6 +163,7 @@ export function Neuroevolution() {
           bestEver: 0,
           bestTicks: 0,
           bestNet: null,
+          stall: 0,
           history: [],
           timeHistory: [],
         };
@@ -199,6 +200,7 @@ export function Neuroevolution() {
         bestEver: saved.bestEver,
         bestTicks: saved.bestTicks,
         bestNet: saved.bestNet ?? null,
+        stall: 0,
         history: saved.history,
         timeHistory: saved.timeHistory ?? [],
       };
@@ -358,6 +360,7 @@ export function Neuroevolution() {
       bestEver: 0,
       bestTicks: 0,
       bestNet: null,
+      stall: 0,
       history: [],
       timeHistory: [],
     };

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -17,6 +17,8 @@ interface Saved {
   generation: number;
   bestEver: number;
   bestTicks: number;
+  // Record-holder brain; optional so pre-existing saves still load.
+  bestNet?: Network | null;
   history: number[];
   timeHistory: number[];
 }
@@ -30,6 +32,7 @@ export function saveWorld(world: World): void {
       generation: world.generation,
       bestEver: world.bestEver,
       bestTicks: world.bestTicks,
+      bestNet: world.bestNet,
       history: world.history,
       timeHistory: world.timeHistory,
     };

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -17,8 +17,10 @@ interface Saved {
   generation: number;
   bestEver: number;
   bestTicks: number;
-  // Record-holder brain; optional so pre-existing saves still load.
+  // Champions; optional so pre-existing saves still load.
   bestNet?: Network | null;
+  generalScore?: number;
+  generalNet?: Network | null;
   history: number[];
   timeHistory: number[];
 }
@@ -33,6 +35,8 @@ export function saveWorld(world: World): void {
       bestEver: world.bestEver,
       bestTicks: world.bestTicks,
       bestNet: world.bestNet,
+      generalScore: world.generalScore,
+      generalNet: world.generalNet,
       history: world.history,
       timeHistory: world.timeHistory,
     };

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -58,6 +58,37 @@ describe("stepWorld", () => {
     expect(w.bestNet).not.toBe(recordNet); // ...as a clone
   });
 
+  describe("immigrant diversity rescue", () => {
+    // A world with a record in place and everyone else crashed, so each step
+    // ends the generation with no new record (progress is stalled).
+    const stalledWorld = (seed: number) => {
+      const w = createWorld(
+        { ...config, stallRounds: 3, immigrants: 4 },
+        viewport,
+        mulberry32(seed),
+      );
+      w.bestTicks = 500; // pretend a record already exists to beat
+      w.cars.forEach((c) => (c.alive = false));
+      return w;
+    };
+    const stalledConfig = { ...config, stallRounds: 3, immigrants: 4 };
+
+    it("counts stalled generations while nothing beats the record", () => {
+      const w = stalledWorld(20);
+      stepWorld(w, stalledConfig, mulberry32(21));
+      expect(w.stall).toBe(1);
+    });
+
+    it("injects immigrants and resets the counter once stalled long enough", () => {
+      const w = stalledWorld(22);
+      w.stall = stalledConfig.stallRounds - 1; // one step from the threshold
+      stepWorld(w, stalledConfig, mulberry32(23));
+      // Reset to 0 here only happens when the immigrant burst fires (no record
+      // was set), so this confirms the injection triggered.
+      expect(w.stall).toBe(0);
+    });
+  });
+
   it("ends the generation early once every car has crashed", () => {
     const w = createWorld(config, viewport, mulberry32(6));
     const rand = mulberry32(7);

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -58,6 +58,15 @@ describe("stepWorld", () => {
     expect(w.bestNet).not.toBe(recordNet); // ...as a clone
   });
 
+  it("crowns a generalist from the held-out battery each generation", () => {
+    const w = createWorld(config, viewport, mulberry32(30));
+    expect(w.generalNet).toBeNull();
+    w.cars.forEach((c) => (c.alive = false)); // end the generation this step
+    stepWorld(w, config, mulberry32(31));
+    expect(w.generalNet).not.toBeNull();
+    expect(w.generalScore).toBeGreaterThan(0);
+  });
+
   describe("immigrant diversity rescue", () => {
     // A world with a record in place and everyone else crashed, so each step
     // ends the generation with no new record (progress is stalled).

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -45,6 +45,19 @@ describe("stepWorld", () => {
     expect(activeCount(w)).toBe(12); // fresh population
   });
 
+  it("keeps the record-holder's brain when a new best time is set", () => {
+    const w = createWorld(config, viewport, mulberry32(11));
+    // One finisher, everyone else out, so the generation ends this step.
+    w.cars.forEach((c) => (c.alive = false));
+    w.cars[0].done = true;
+    w.cars[0].finishTicks = 500;
+    const recordNet = w.cars[0].net;
+    stepWorld(w, config, mulberry32(12));
+    expect(w.bestTicks).toBe(500);
+    expect(w.bestNet).toEqual(recordNet); // captured...
+    expect(w.bestNet).not.toBe(recordNet); // ...as a clone
+  });
+
   it("ends the generation early once every car has crashed", () => {
     const w = createWorld(config, viewport, mulberry32(6));
     const rand = mulberry32(7);

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -25,6 +25,11 @@ export interface SimConfig extends EvolveConfig {
   // generation, so the population is selected for driving in general rather
   // than for one specific layout.
   varyTrack: boolean;
+  // Diversity rescue: after this many generations with no new record, replace
+  // the weakest `immigrants` bred slots with fresh random brains to re-open
+  // exploration (0 rounds disables it).
+  stallRounds: number;
+  immigrants: number;
 }
 
 export const DEFAULT_CONFIG: SimConfig = {
@@ -35,6 +40,8 @@ export const DEFAULT_CONFIG: SimConfig = {
   mutationStrength: 0.4,
   maxSteps: FINISH_TIME_BUDGET,
   varyTrack: false,
+  stallRounds: 12,
+  immigrants: 6,
 };
 
 export interface Viewport {
@@ -52,6 +59,8 @@ export interface World {
   bestTicks: number;
   // The brain that set bestTicks — the record-holder, raced in solo / exported.
   bestNet: Network | null;
+  // Generations since the last record, for the immigrant diversity rescue.
+  stall: number;
   // Best fitness of each completed generation.
   history: number[];
   // Best finish time (ticks) of each generation, 0 if none finished. Drives the
@@ -77,6 +86,7 @@ export function createWorld(
     bestEver: 0,
     bestTicks: 0,
     bestNet: null,
+    stall: 0,
     history: [],
     timeHistory: [],
   };
@@ -161,12 +171,18 @@ function endGeneration(
   }
   const genTicks = recordCar ? recordCar.finishTicks : 0;
   world.timeHistory.push(genTicks);
+  let improved = false;
   if (recordCar && (world.bestTicks === 0 || genTicks < world.bestTicks)) {
     world.bestTicks = genTicks;
     world.bestNet = cloneNetwork(recordCar.net);
+    improved = true;
   }
 
+  // Track how long lap-time progress has stalled, once there's a record to beat.
+  if (world.bestTicks > 0) world.stall = improved ? 0 : world.stall + 1;
+
   const nets = evolve(scored, config, rand);
+
   // Domain randomization reshuffles the course each generation; the fastest-run
   // record only means something on a fixed track, so reset it when varying.
   if (config.varyTrack) {
@@ -176,7 +192,19 @@ function endGeneration(
     );
     world.bestTicks = 0;
     world.bestNet = null;
+    world.stall = 0;
   }
+
+  // Diversity rescue: after a long stall, replace the weakest bred slots (never
+  // the elites) with fresh random brains, then reset so bursts stay spaced out.
+  if (config.immigrants > 0 && world.stall >= config.stallRounds) {
+    const start = Math.max(config.eliteCount, nets.length - config.immigrants);
+    for (let i = start; i < nets.length; i++) {
+      nets[i] = createNetwork(BRAIN_SHAPE, rand);
+    }
+    world.stall = 0;
+  }
+
   world.cars = nets.map((net) => createCar(net, world.track));
   world.generation += 1;
   world.step = 0;

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -14,7 +14,7 @@ import {
   type EvolveConfig,
   type Scored,
 } from "./genetic";
-import { createNetwork } from "./nn";
+import { cloneNetwork, createNetwork, type Network } from "./nn";
 import { buildTrack, type Track } from "./track";
 
 export interface SimConfig extends EvolveConfig {
@@ -50,6 +50,8 @@ export interface World {
   bestEver: number;
   // Fewest ticks any car has ever taken to finish (0 = nobody has yet).
   bestTicks: number;
+  // The brain that set bestTicks — the record-holder, raced in solo / exported.
+  bestNet: Network | null;
   // Best fitness of each completed generation.
   history: number[];
   // Best finish time (ticks) of each generation, 0 if none finished. Drives the
@@ -74,6 +76,7 @@ export function createWorld(
     step: 0,
     bestEver: 0,
     bestTicks: 0,
+    bestNet: null,
     history: [],
     timeHistory: [],
   };
@@ -148,10 +151,19 @@ function endGeneration(
   world.history.push(stats.best);
   if (stats.best > world.bestEver) world.bestEver = stats.best;
 
-  const genTicks = bestFinishTicks(world);
+  // Fastest finisher this generation; keep its brain if it's an all-time record
+  // so solo/export always race the actual record-holder.
+  let recordCar: Car | null = null;
+  for (const c of world.cars) {
+    if (c.done && (!recordCar || c.finishTicks < recordCar.finishTicks)) {
+      recordCar = c;
+    }
+  }
+  const genTicks = recordCar ? recordCar.finishTicks : 0;
   world.timeHistory.push(genTicks);
-  if (genTicks > 0 && (world.bestTicks === 0 || genTicks < world.bestTicks)) {
+  if (recordCar && (world.bestTicks === 0 || genTicks < world.bestTicks)) {
     world.bestTicks = genTicks;
+    world.bestNet = cloneNetwork(recordCar.net);
   }
 
   const nets = evolve(scored, config, rand);
@@ -163,6 +175,7 @@ function endGeneration(
       rand,
     );
     world.bestTicks = 0;
+    world.bestNet = null;
   }
   world.cars = nets.map((net) => createCar(net, world.track));
   world.generation += 1;

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -4,10 +4,12 @@
 import {
   BRAIN_SHAPE,
   FINISH_TIME_BUDGET,
+  LAPS_TO_FINISH,
   createCar,
   stepCar,
   type Car,
 } from "./car";
+import { mulberry32 } from "./geometry";
 import {
   computeStats,
   evolve,
@@ -55,10 +57,16 @@ export interface World {
   generation: number;
   step: number;
   bestEver: number;
-  // Fewest ticks any car has ever taken to finish (0 = nobody has yet).
+  // --- Track champion: fastest on THIS track (a specialist) ---
+  // Fewest ticks any car has taken to finish the current track (0 = none yet).
   bestTicks: number;
-  // The brain that set bestTicks — the record-holder, raced in solo / exported.
+  // The brain that set bestTicks — the track record-holder.
   bestNet: Network | null;
+  // --- Generalist champion: best across ALL tracks (a robust all-rounder) ---
+  // Worst-case cost over a fixed held-out battery for the best generaliser seen
+  // (0 = none yet; lower is better). Track-independent, so it persists.
+  generalScore: number;
+  generalNet: Network | null;
   // Generations since the last record, for the immigrant diversity rescue.
   stall: number;
   // Best fitness of each completed generation.
@@ -86,10 +94,47 @@ export function createWorld(
     bestEver: 0,
     bestTicks: 0,
     bestNet: null,
+    generalScore: 0,
+    generalNet: null,
     stall: 0,
     history: [],
     timeHistory: [],
   };
+}
+
+// A fixed, seeded set of held-out tracks the population never trains on — a
+// validation set for measuring how well a brain generalises.
+const BATTERY_SEEDS = [9001, 9002, 9003, 9004, 9005];
+let batteryCache: { key: string; tracks: Track[] } | null = null;
+
+function validationBattery(width: number, height: number): Track[] {
+  const key = `${width}x${height}`;
+  if (!batteryCache || batteryCache.key !== key) {
+    batteryCache = {
+      key,
+      tracks: BATTERY_SEEDS.map((s) => buildTrack({ width, height }, mulberry32(s))),
+    };
+  }
+  return batteryCache.tracks;
+}
+
+// Worst-case cost of a brain over the battery (lower = more general): its
+// slowest finish, or a heavy penalty plus distance shortfall for any track it
+// fails to finish. Worst-case selection favours "never crashes on the unknown".
+export function evaluateGenerality(net: Network, battery: Track[]): number {
+  let worst = 0;
+  for (const track of battery) {
+    const car = createCar(net, track);
+    for (let i = 0; i < FINISH_TIME_BUDGET && car.alive && !car.done; i++) {
+      stepCar(car, track);
+    }
+    const target = LAPS_TO_FINISH * track.gates.length;
+    const cost = car.done
+      ? car.finishTicks
+      : FINISH_TIME_BUDGET + (target - car.gatesPassed);
+    if (cost > worst) worst = cost;
+  }
+  return worst;
 }
 
 // A car still driving: alive and not yet finished.
@@ -182,6 +227,18 @@ function endGeneration(
   if (world.bestTicks > 0) world.stall = improved ? 0 : world.stall + 1;
 
   const nets = evolve(scored, config, rand);
+
+  // Generalist champion (separate from the track record): score this
+  // generation's best on the held-out battery and keep whichever brain
+  // generalises best. Track-independent, so it survives track changes.
+  const score = evaluateGenerality(
+    nets[0],
+    validationBattery(world.track.width, world.track.height),
+  );
+  if (world.generalScore === 0 || score < world.generalScore) {
+    world.generalScore = score;
+    world.generalNet = cloneNetwork(nets[0]);
+  }
 
   // Domain randomization reshuffles the course each generation; the fastest-run
   // record only means something on a fixed track, so reset it when varying.


### PR DESCRIPTION
## What

Three related improvements to how the neuroevolution playground selects and keeps brains (each builds on the previous one's generation-loop changes, hence one PR):

### 1. Race/export the record-holder, not the current leader
Retain `bestNet` (clone of the genome that set `bestTicks`) and spotlight it for solo/export. Solo/export previously used the current-fitness leader, so a solo run rarely matched "Fastest run". Deterministic sim → the retained record-holder reproduces the record exactly.

### 2. Stall-triggered random immigrants
When no new record lands for `stallRounds` generations (default 12), replace the weakest `immigrants` bred slots (default 6) with fresh random brains, then reset the counter. Elites/record are never touched → re-opens exploration, never regresses. The automatic version of periodically hitting "Breed from it".

### 3. Separate all-tracks generalist champion
Splits "best" into two first-class champions instead of overloading one:
- **Track champion** (`bestNet`/`bestTicks`): fastest on the current track (a specialist).
- **Generalist** (`generalNet`/`generalScore`): best worst-case time over a fixed held-out **battery** of 5 tracks the population never trains on (a validation set). Worst-case selection favours "never crashes on the unknown".

The generalist is maintained every generation, is track-independent (survives "New track"), and is persisted. A telemetry readout shows its worst-of-5 time; a **Spotlight** selector chooses which champion solo/export/breed target. Grow it by turning on **Vary track**.

## Why

`bestTicks` conflated "fastest here" with "best overall". A brain hyper-tuned to one track often crashes on a new one (overfitting). Training with vary-track and *keeping the brain that scores best on held-out tracks* gives a robust all-rounder you can spotlight/export separately from the track specialist.

## Testing

- 53 unit tests pass (added: record-holder captured as a clone; stall counter + immigrant burst; generalist crowned from the battery each generation)
- typecheck clean, lint clean for touched files, production build green
- Generalisation harness (removed): trained on one track, a specialist finished **6/10** unseen tracks; the vary-track generalist finished **10/10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)