### PR TITLE
refactor: tidy the neuroevolution controls and fix low contrast

### DIFF
--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
@@ -26,7 +26,7 @@ export function NetworkView({ net }: { net: Network | null }) {
 
   if (!layout) {
     return (
-      <div className="flex h-[200px] items-center justify-center font-mono text-[11px] uppercase tracking-widest text-white/30">
+      <div className="flex h-[200px] items-center justify-center font-readout text-[11px] uppercase tracking-widest text-[var(--muted)]">
         no leader yet
       </div>
     );
@@ -54,7 +54,7 @@ export function NetworkView({ net }: { net: Network | null }) {
               x={n.labelRight ? n.x + 9 : n.x - 9}
               y={n.y + 3}
               textAnchor={n.labelRight ? "start" : "end"}
-              className="fill-white/45 font-readout"
+              className="fill-white/75 font-readout"
               fontSize={7}
             >
               {n.label}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -466,14 +466,45 @@ export function Neuroevolution() {
               Neuro<span className="text-[var(--cyan)]">evolution</span>
             </h1>
           </div>
-          <div className="flex items-stretch gap-4">
+          <div className="flex items-end gap-4">
             <HeaderStat label="Gen" value={solo ? "—" : String(stats.generation)} />
-            <div className="w-px bg-[var(--line)]" />
-            <HeaderStat
-              label="Mode"
-              value={solo ? "Solo" : "Evolve"}
-              accent={solo ? "var(--amber)" : "var(--cyan)"}
-            />
+            <div className="w-px self-stretch bg-[var(--line)]" />
+            <div>
+              <div className="mb-1 text-right font-readout text-[9px] uppercase tracking-[0.3em] text-[var(--muted)]">
+                Mode
+              </div>
+              <div className="flex overflow-hidden rounded-sm border border-[var(--line-2)]">
+                {(
+                  [
+                    ["evolve", "Evolve"],
+                    ["solo", "Solo"],
+                  ] as const
+                ).map(([m, label]) => {
+                  const active = solo ? m === "solo" : m === "evolve";
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => {
+                        if ((m === "solo") !== solo) toggleSolo();
+                      }}
+                      title={
+                        m === "solo"
+                          ? "Race the spotlighted champion on its own"
+                          : "Evolve the population"
+                      }
+                      className={`px-3 py-1.5 font-readout text-[11px] uppercase tracking-[0.18em] transition-colors ${
+                        active
+                          ? "bg-[var(--cyan)]/20 text-[var(--cyan)]"
+                          : "text-[var(--muted)] hover:text-[var(--text)]"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           </div>
         </header>
 
@@ -760,14 +791,6 @@ export function Neuroevolution() {
                 </button>
               ))}
             </div>
-            <div className="mx-1 h-5 w-px bg-[var(--line)]" />
-            <DeckButton
-              onClick={toggleSolo}
-              tone={solo ? "amber" : "line"}
-              title="Race the spotlighted champion on its own, looping"
-            >
-              {solo ? "Back to evolving" : "Race solo"}
-            </DeckButton>
             <div className="mx-1 h-5 w-px bg-[var(--line)]" />
             <DeckButton onClick={downloadBrain} title="Save the best brain to a file">
               ↓ Export

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -67,14 +67,16 @@
 .neuro-console {
   --ink: #07090c;
   --panel: #0d1016;
-  --line: rgba(150, 180, 205, 0.14);
-  --line-2: rgba(150, 180, 205, 0.28);
-  --text: #e9eff3;
-  --muted: rgba(233, 239, 243, 0.44);
+  /* Structural lines nudged up for visible edges; text tokens raised to clear
+     WCAG AA on the dark panels. */
+  --line: rgba(150, 180, 205, 0.2);
+  --line-2: rgba(150, 180, 205, 0.42);
+  --text: #eef3f7;
+  --muted: rgba(226, 234, 240, 0.72);
   --amber: #f7c948;
-  --cyan: #45c8d8;
-  --red: #ff5140;
-  --mint: #35d6a0;
+  --cyan: #5ad3e2;
+  --red: #ff6a5c;
+  --mint: #46e0ad;
 }
 
 @utility font-telemetry {


### PR DESCRIPTION
## What

Cleans up the neuroevolution playground controls and fixes low contrast.

- **One clear mode switch up top.** Evolve/Solo is now a segmented control in the header instead of a "Race solo" button buried among the champion actions. The Garage row now holds only champion actions (spotlight, export, import, breed).
- **Contrast raised to clear WCAG AA** on the dark panels:
  - The muted label token (used by nearly every label) went from ~44% to 72% opacity, roughly 3:1 up to ~8:1 against the panels.
  - Structural lines are slightly stronger, and the cyan / mint / red accents are brighter.
  - Fixed two low-opacity labels in the network diagram (`white/30` and `white/45`).

## Why

The controls had grown into two dense rows with the mode entry point scattered and easy to miss, and a lot of text was low-opacity muted grey that failed contrast on the near-black background.

## Note

This is a focused pass. A bigger follow-up would be making the run controls mode-aware (hide the evolution-only ones, mutation, vary track, fresh start, breed, while in Solo), but I kept this to the mode switch, declutter, and contrast so it's easy to review.

## Testing

53 unit tests pass, typecheck clean, lint clean for touched files, production build green, page serves 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)