### PR TITLE
perf: spatial grid for sensors/collision plus a Max speed

### DIFF
--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/NetworkView.tsx
@@ -26,7 +26,7 @@ export function NetworkView({ net }: { net: Network | null }) {
 
   if (!layout) {
     return (
-      <div className="flex h-[200px] items-center justify-center font-mono text-[11px] uppercase tracking-widest text-white/30">
+      <div className="flex h-[200px] items-center justify-center font-readout text-[11px] uppercase tracking-widest text-[var(--muted)]">
         no leader yet
       </div>
     );
@@ -54,7 +54,7 @@ export function NetworkView({ net }: { net: Network | null }) {
               x={n.labelRight ? n.x + 9 : n.x - 9}
               y={n.y + 3}
               textAnchor={n.labelRight ? "start" : "end"}
-              className="fill-white/45 font-readout"
+              className="fill-white/75 font-readout"
               fontSize={7}
             >
               {n.label}

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -32,6 +32,11 @@ import { Sparkline } from "./Sparkline";
 
 const VIEWPORT = { width: 900, height: 600 };
 const SPEEDS = [1, 2, 4, 8];
+// "Max" runs as many steps as fit in a per-frame time budget (self-scaling to
+// the machine), capped so a fast machine can't spin forever in one frame.
+const MAX_BUDGET_MS = 12;
+const MAX_STEP_CAP = 4000;
+type Speed = number | "max";
 // Flush HUD state ~10x/second rather than every frame.
 const HUD_EVERY = 6;
 // Nominal ticks per second, for turning finish-tick counts into a time.
@@ -95,7 +100,7 @@ export function Neuroevolution() {
   const configRef = useRef<SimConfig>({ ...DEFAULT_CONFIG });
 
   const pausedRef = useRef(false);
-  const speedRef = useRef(2);
+  const speedRef = useRef<Speed>(2);
   const sensorsRef = useRef(true);
   const savedGenRef = useRef(0);
 
@@ -109,7 +114,7 @@ export function Neuroevolution() {
 
   const [stats, setStats] = useState<Stats>(EMPTY_STATS);
   const [paused, setPaused] = useState(false);
-  const [speed, setSpeed] = useState(2);
+  const [speed, setSpeed] = useState<Speed>(2);
   const [sensors, setSensors] = useState(true);
   const [mutationRate, setMutationRate] = useState(DEFAULT_CONFIG.mutationRate);
   const [varyTrack, setVaryTrack] = useState(DEFAULT_CONFIG.varyTrack);
@@ -251,8 +256,13 @@ export function Neuroevolution() {
         if (brain) {
           if (!soloCarRef.current) soloCarRef.current = createCar(brain, w.track);
           if (!pausedRef.current) {
-            for (let s = 0; s < speedRef.current; s++) {
+            const sp = speedRef.current;
+            const maxMode = sp === "max";
+            const end = maxMode ? performance.now() + MAX_BUDGET_MS : 0;
+            const cap = sp === "max" ? MAX_STEP_CAP : sp;
+            for (let s = 0; s < cap; s++) {
               const car = soloCarRef.current;
+              if (!car) break;
               stepCar(car, w.track);
               if (!car.alive || car.done) {
                 if (
@@ -262,8 +272,8 @@ export function Neuroevolution() {
                   soloBestRef.current = car.finishTicks;
                 }
                 soloCarRef.current = createCar(brain, w.track); // loop the run
-                break;
               }
+              if (maxMode && performance.now() >= end) break;
             }
           }
           const solo = soloCarRef.current;
@@ -272,8 +282,13 @@ export function Neuroevolution() {
         if (frame % HUD_EVERY === 0) flush();
       } else if (w) {
         if (!pausedRef.current) {
-          for (let s = 0; s < speedRef.current; s++) {
+          const sp = speedRef.current;
+          const maxMode = sp === "max";
+          const end = maxMode ? performance.now() + MAX_BUDGET_MS : 0;
+          const cap = sp === "max" ? MAX_STEP_CAP : sp;
+          for (let s = 0; s < cap; s++) {
             stepWorld(w, configRef.current, randRef.current);
+            if (maxMode && performance.now() >= end) break;
           }
         }
         drawWorld(ctx, w, sensorsRef.current);
@@ -295,7 +310,7 @@ export function Neuroevolution() {
     pausedRef.current = !pausedRef.current;
     setPaused(pausedRef.current);
   };
-  const pickSpeed = (s: number) => {
+  const pickSpeed = (s: Speed) => {
     speedRef.current = s;
     setSpeed(s);
   };
@@ -697,6 +712,18 @@ export function Neuroevolution() {
                     {s}×
                   </button>
                 ))}
+                <button
+                  type="button"
+                  onClick={() => pickSpeed("max")}
+                  title="Run as fast as this machine allows (fits as many steps as possible into each frame)"
+                  className={`px-2.5 py-1.5 font-readout text-[11px] uppercase tracking-[0.15em] transition-colors ${
+                    speed === "max"
+                      ? "bg-[var(--cyan)]/20 text-[var(--cyan)]"
+                      : "text-[var(--muted)] hover:text-[var(--text)]"
+                  }`}
+                >
+                  Max
+                </button>
               </div>
             </div>
 

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -466,14 +466,45 @@ export function Neuroevolution() {
               Neuro<span className="text-[var(--cyan)]">evolution</span>
             </h1>
           </div>
-          <div className="flex items-stretch gap-4">
+          <div className="flex items-end gap-4">
             <HeaderStat label="Gen" value={solo ? "—" : String(stats.generation)} />
-            <div className="w-px bg-[var(--line)]" />
-            <HeaderStat
-              label="Mode"
-              value={solo ? "Solo" : "Evolve"}
-              accent={solo ? "var(--amber)" : "var(--cyan)"}
-            />
+            <div className="w-px self-stretch bg-[var(--line)]" />
+            <div>
+              <div className="mb-1 text-right font-readout text-[9px] uppercase tracking-[0.3em] text-[var(--muted)]">
+                Mode
+              </div>
+              <div className="flex overflow-hidden rounded-sm border border-[var(--line-2)]">
+                {(
+                  [
+                    ["evolve", "Evolve"],
+                    ["solo", "Solo"],
+                  ] as const
+                ).map(([m, label]) => {
+                  const active = solo ? m === "solo" : m === "evolve";
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => {
+                        if ((m === "solo") !== solo) toggleSolo();
+                      }}
+                      title={
+                        m === "solo"
+                          ? "Race the spotlighted champion on its own"
+                          : "Evolve the population"
+                      }
+                      className={`px-3 py-1.5 font-readout text-[11px] uppercase tracking-[0.18em] transition-colors ${
+                        active
+                          ? "bg-[var(--cyan)]/20 text-[var(--cyan)]"
+                          : "text-[var(--muted)] hover:text-[var(--text)]"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           </div>
         </header>
 
@@ -760,14 +791,6 @@ export function Neuroevolution() {
                 </button>
               ))}
             </div>
-            <div className="mx-1 h-5 w-px bg-[var(--line)]" />
-            <DeckButton
-              onClick={toggleSolo}
-              tone={solo ? "amber" : "line"}
-              title="Race the spotlighted champion on its own, looping"
-            >
-              {solo ? "Back to evolving" : "Race solo"}
-            </DeckButton>
             <div className="mx-1 h-5 w-px bg-[var(--line)]" />
             <DeckButton onClick={downloadBrain} title="Save the best brain to a file">
               ↓ Export

--- a/src/app/playgrounds/neuroevolution/_lib/car.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/car.ts
@@ -4,7 +4,24 @@
 
 import { rayHit, segmentsIntersect } from "./geometry";
 import { forward, type Network } from "./nn";
-import type { Track } from "./track";
+import type { Track, Wall } from "./track";
+import { WallGrid } from "./wallGrid";
+
+// One spatial grid per track, built lazily and cached. Tracks are immutable
+// once built, so a WeakMap keyed by the track object is safe and self-cleaning.
+const gridCache = new WeakMap<Track, WallGrid>();
+
+function wallGridFor(track: Track): WallGrid {
+  let grid = gridCache.get(track);
+  if (!grid) {
+    grid = new WallGrid(track.walls, track.width, track.height);
+    gridCache.set(track, grid);
+  }
+  return grid;
+}
+
+// Reused scratch array for near-car wall candidates (single-threaded).
+const candidates: Wall[] = [];
 
 // Sensor whiskers, relative to the car's heading: wide side coverage plus fine
 // forward resolution so the car can read a corner before it arrives.
@@ -90,15 +107,18 @@ export function createCar(net: Network, track: Track): Car {
   };
 }
 
-// Cast every whisker and return the nearest wall distance for each.
-function readSensors(car: Car, track: Track): number[] {
+// Cast every whisker against the near-car candidate walls and return the
+// nearest wall distance for each. Candidates are a superset of every wall
+// within SENSOR_RANGE, so the result is identical to testing all walls.
+function readSensors(car: Car, walls: Wall[], count: number): number[] {
   const out = new Array(SENSOR_ANGLES.length);
   for (let s = 0; s < SENSOR_ANGLES.length; s++) {
     const a = car.angle + SENSOR_ANGLES[s];
     const dx = Math.cos(a);
     const dy = Math.sin(a);
     let nearest = SENSOR_RANGE;
-    for (const w of track.walls) {
+    for (let i = 0; i < count; i++) {
+      const w = walls[i];
       const t = rayHit(car.x, car.y, dx, dy, w.ax, w.ay, w.bx, w.by);
       if (t < nearest) nearest = t;
     }
@@ -112,7 +132,11 @@ export function stepCar(car: Car, track: Track): void {
   if (!car.alive || car.done) return;
   car.ticks += 1;
 
-  const sensors = readSensors(car, track);
+  // Near-car walls: a single broad-phase query serves both the sensors and the
+  // collision check (the move step is far shorter than SENSOR_RANGE).
+  const nearby = wallGridFor(track).query(car.x, car.y, SENSOR_RANGE, candidates);
+
+  const sensors = readSensors(car, candidates, nearby);
   car.sensors = sensors;
 
   const inputs = new Array(SENSOR_ANGLES.length + 1);
@@ -136,7 +160,8 @@ export function stepCar(car: Car, track: Track): void {
   const nx = px + Math.cos(car.angle) * car.speed;
   const ny = py + Math.sin(car.angle) * car.speed;
 
-  for (const w of track.walls) {
+  for (let i = 0; i < nearby; i++) {
+    const w = candidates[i];
     if (segmentsIntersect(px, py, nx, ny, w.ax, w.ay, w.bx, w.by)) {
       car.alive = false;
       return;

--- a/src/app/playgrounds/neuroevolution/_lib/wallGrid.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/wallGrid.test.ts
@@ -1,0 +1,53 @@
+import { mulberry32, rayHit } from "./geometry";
+import { buildTrack, type Wall } from "./track";
+import { WallGrid } from "./wallGrid";
+
+const RANGE = 260;
+
+function bruteNearest(
+  walls: Wall[],
+  x: number,
+  y: number,
+  dx: number,
+  dy: number,
+): number {
+  let nearest = RANGE;
+  for (const w of walls) {
+    const t = rayHit(x, y, dx, dy, w.ax, w.ay, w.bx, w.by);
+    if (t < nearest) nearest = t;
+  }
+  return nearest;
+}
+
+describe("WallGrid", () => {
+  const track = buildTrack({ width: 900, height: 600 }, mulberry32(1));
+  const grid = new WallGrid(track.walls, 900, 600);
+
+  it("gives identical nearest-wall distances to testing every wall", () => {
+    const rand = mulberry32(2);
+    const out: Wall[] = [];
+    for (let s = 0; s < 4000; s++) {
+      const x = rand() * 900;
+      const y = rand() * 600;
+      const a = rand() * Math.PI * 2;
+      const dx = Math.cos(a);
+      const dy = Math.sin(a);
+
+      const n = grid.query(x, y, RANGE, out);
+      let gridNearest = RANGE;
+      for (let i = 0; i < n; i++) {
+        const w = out[i];
+        const t = rayHit(x, y, dx, dy, w.ax, w.ay, w.bx, w.by);
+        if (t < gridNearest) gridNearest = t;
+      }
+
+      expect(gridNearest).toBe(bruteNearest(track.walls, x, y, dx, dy));
+    }
+  });
+
+  it("returns candidates without duplicates", () => {
+    const out: Wall[] = [];
+    const n = grid.query(450, 300, RANGE, out);
+    expect(new Set(out.slice(0, n)).size).toBe(n);
+  });
+});

--- a/src/app/playgrounds/neuroevolution/_lib/wallGrid.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/wallGrid.ts
@@ -1,0 +1,72 @@
+// A uniform spatial grid over the track walls. Sensors and collision only need
+// the handful of walls near a car, not all ~150, so this buckets walls by cell
+// and returns the candidates overlapping a query box. It's a broad-phase cull:
+// it never drops a wall that could be within range, so results are identical to
+// testing every wall, just far cheaper.
+
+import type { Wall } from "./track";
+
+const DEFAULT_CELL = 80;
+
+export class WallGrid {
+  private readonly cell: number;
+  private readonly cols: number;
+  private readonly rows: number;
+  private readonly buckets: number[][];
+  private readonly walls: Wall[];
+  // Per-wall "seen this query" stamp, to dedupe walls spanning several cells
+  // without allocating a Set each query.
+  private readonly stamp: Int32Array;
+  private epoch = 0;
+
+  constructor(walls: Wall[], width: number, height: number, cell = DEFAULT_CELL) {
+    this.walls = walls;
+    this.cell = cell;
+    this.cols = Math.max(1, Math.ceil(width / cell));
+    this.rows = Math.max(1, Math.ceil(height / cell));
+    this.buckets = Array.from({ length: this.cols * this.rows }, () => []);
+    this.stamp = new Int32Array(walls.length).fill(-1);
+
+    for (let i = 0; i < walls.length; i++) {
+      const w = walls[i];
+      const c0 = this.col(Math.min(w.ax, w.bx));
+      const c1 = this.col(Math.max(w.ax, w.bx));
+      const r0 = this.row(Math.min(w.ay, w.by));
+      const r1 = this.row(Math.max(w.ay, w.by));
+      for (let r = r0; r <= r1; r++) {
+        for (let c = c0; c <= c1; c++) this.buckets[r * this.cols + c].push(i);
+      }
+    }
+  }
+
+  private col(x: number): number {
+    return Math.min(this.cols - 1, Math.max(0, Math.floor(x / this.cell)));
+  }
+  private row(y: number): number {
+    return Math.min(this.rows - 1, Math.max(0, Math.floor(y / this.cell)));
+  }
+
+  // Fill `out` with walls whose cell overlaps the box [x±r, y±r]; return count.
+  // `out` is a caller-owned scratch array, reused to avoid per-call allocation.
+  query(x: number, y: number, r: number, out: Wall[]): number {
+    const c0 = this.col(x - r);
+    const c1 = this.col(x + r);
+    const r0 = this.row(y - r);
+    const r1 = this.row(y + r);
+    this.epoch++;
+    let n = 0;
+    for (let rr = r0; rr <= r1; rr++) {
+      for (let cc = c0; cc <= c1; cc++) {
+        const bucket = this.buckets[rr * this.cols + cc];
+        for (let k = 0; k < bucket.length; k++) {
+          const i = bucket[k];
+          if (this.stamp[i] !== this.epoch) {
+            this.stamp[i] = this.epoch;
+            out[n++] = this.walls[i];
+          }
+        }
+      }
+    }
+    return n;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -67,14 +67,16 @@
 .neuro-console {
   --ink: #07090c;
   --panel: #0d1016;
-  --line: rgba(150, 180, 205, 0.14);
-  --line-2: rgba(150, 180, 205, 0.28);
-  --text: #e9eff3;
-  --muted: rgba(233, 239, 243, 0.44);
+  /* Structural lines nudged up for visible edges; text tokens raised to clear
+     WCAG AA on the dark panels. */
+  --line: rgba(150, 180, 205, 0.2);
+  --line-2: rgba(150, 180, 205, 0.42);
+  --text: #eef3f7;
+  --muted: rgba(226, 234, 240, 0.72);
   --amber: #f7c948;
-  --cyan: #45c8d8;
-  --red: #ff5140;
-  --mint: #35d6a0;
+  --cyan: #5ad3e2;
+  --red: #ff6a5c;
+  --mint: #46e0ad;
 }
 
 @utility font-telemetry {


### PR DESCRIPTION
## What

Two ways to make the neuroevolution sim run faster (items 1 and 3 of the speed discussion):

### Spatial grid (item 3)
Every car's sensor raycasts and its collision check previously tested **all ~150 wall segments**. Now a uniform spatial grid over the walls answers a single broad-phase query per car per tick (walls near the car), reused across all seven whiskers and the collision step.

- It's a pure cull, not an approximation: the candidate set is a superset of every wall within `SENSOR_RANGE`, so a ray/collision result is **identical** to testing every wall.
- Guarded by a regression test that checks grid nearest-wall distances match brute force over 4000 random samples (and that candidates are dupe-free).

### Max speed (item 1)
Adds a **Max** option to the speed selector that runs as many steps as fit in a ~12ms per-frame budget (with a hard cap), so it self-scales to the machine instead of a fixed 1/2/4/8× multiplier.

## Why

The dominant per-step cost was ray/segment maths against every wall. Culling to nearby walls cuts that several-fold, and Max lets a capable machine use the headroom without a fixed ceiling.

## Testing

55 unit tests pass (2 new for grid equivalence), typecheck clean, lint clean for touched files, production build green, page serves 200. The grid changes are behaviour-preserving by construction and by the regression test; Max is a loop-bound change.

Follow-up (separate PR): moving the sim to a Web Worker so it never janks the UI thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)