### PR TITLE
perf: lexicographic multi-track selection for vary-track generalists

### DIFF
--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -56,6 +56,8 @@ interface Stats {
   idealTicks: number;
   // How many of the held-out battery tracks the crowned generalist finishes.
   generalFinishes: number;
+  // Mean finish time (ticks) of the crowned generalist over the battery.
+  generalMeanTicks: number;
   runTimes: number[];
   leaderNet: Network | null;
   // Solo-mode fields.
@@ -76,6 +78,7 @@ const EMPTY_STATS: Stats = {
   bestTicks: 0,
   idealTicks: 0,
   generalFinishes: 0,
+  generalMeanTicks: 0,
   runTimes: [],
   leaderNet: null,
   soloLaps: 0,
@@ -136,6 +139,7 @@ export function Neuroevolution() {
         mode: "solo",
         idealTicks: idealRunTicks(track),
         generalFinishes: w.generalFinishes,
+        generalMeanTicks: w.generalMeanTicks,
         leaderNet: championRef.current,
         soloLaps: car ? Math.min(LAPS_TO_FINISH, Math.floor(car.gatesPassed / gateCount)) : 0,
         soloRunTicks: car ? car.ticks : 0,
@@ -161,6 +165,7 @@ export function Neuroevolution() {
       bestTicks,
       idealTicks: idealRunTicks(w.track),
       generalFinishes: w.generalFinishes,
+      generalMeanTicks: w.generalMeanTicks,
       runTimes: w.timeHistory.map((t) => t / 60),
       leaderNet: lead ? lead.net : null,
     }));
@@ -202,6 +207,7 @@ export function Neuroevolution() {
           // over (it's track-independent).
           generalScore: prev.generalScore,
           generalFinishes: prev.generalFinishes,
+          generalMeanTicks: prev.generalMeanTicks,
           generalNet: prev.generalNet,
           stall: 0,
           history: [],
@@ -244,6 +250,7 @@ export function Neuroevolution() {
         bestNet: saved.bestNet ?? null,
         generalScore: saved.generalScore ?? 0,
         generalFinishes: saved.generalFinishes ?? 0,
+        generalMeanTicks: saved.generalMeanTicks ?? 0,
         generalNet: saved.generalNet ?? null,
         stall: 0,
         history: saved.history,
@@ -443,6 +450,7 @@ export function Neuroevolution() {
       bestNet: null,
       generalScore: 0,
       generalFinishes: 0,
+      generalMeanTicks: 0,
       generalNet: null,
       stall: 0,
       history: [],
@@ -659,20 +667,28 @@ export function Neuroevolution() {
                   {deltaS !== null && <DeltaChip delta={deltaS} />}
                 </div>
               </div>
-              {/* Generalist: finishes across the held-out battery (all tracks). */}
+              {/* Generalist: finishes and avg speed across the held-out battery. */}
               <div className="flex items-center justify-between border-t border-[var(--line)] px-3 py-2.5">
                 <span
                   className="font-readout text-[9px] uppercase tracking-[0.25em] text-[var(--muted)]"
-                  title={`How many of ${BATTERY_SIZE} held-out tracks the crowned generalist finishes — tracks the population never trains on. Turn on Vary track to grow this`}
+                  title={`Across ${BATTERY_SIZE} held-out tracks the population never trains on: how many the crowned generalist finishes, and its average finish time on those. After finishes maxes out, watch the time keep dropping. Turn on Vary track to grow this`}
                 >
-                  Generalist · finishes
+                  Generalist
                 </span>
-                <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--cyan)]">
-                  {stats.generalFinishes}
-                  <span className="ml-0.5 text-[10px] text-[var(--muted)]">
-                    /{BATTERY_SIZE}
+                <div className="flex items-baseline gap-3">
+                  <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--cyan)]">
+                    {stats.generalFinishes}
+                    <span className="ml-0.5 text-[10px] text-[var(--muted)]">
+                      /{BATTERY_SIZE}
+                    </span>
                   </span>
-                </span>
+                  <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--cyan)]">
+                    {secs(stats.generalMeanTicks)}
+                    <span className="ml-0.5 text-[10px] text-[var(--muted)]">
+                      s avg
+                    </span>
+                  </span>
+                </div>
               </div>
             </Panel>
 

--- a/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
+++ b/src/app/playgrounds/neuroevolution/_components/Neuroevolution/Neuroevolution.tsx
@@ -5,7 +5,6 @@ import { mulberry32 } from "../../_lib/geometry";
 import type { Network } from "../../_lib/nn";
 import { clearWorld, loadWorld, saveWorld } from "../../_lib/persistence";
 import {
-  FINISH_TIME_BUDGET,
   LAPS_TO_FINISH,
   createCar,
   stepCar,
@@ -18,6 +17,7 @@ import { populationFrom } from "../../_lib/genetic";
 import { parseBrain, serializeBrain } from "../../_lib/brainIO";
 import { display, mono } from "../../_lib/fonts";
 import {
+  BATTERY_SIZE,
   DEFAULT_CONFIG,
   activeCount,
   bestFinishTicks,
@@ -54,9 +54,8 @@ interface Stats {
   genTicks: number;
   bestTicks: number;
   idealTicks: number;
-  // Generalist champion's worst-case time over the held-out battery (0 until it
-  // finishes all of them).
-  generalTicks: number;
+  // How many of the held-out battery tracks the crowned generalist finishes.
+  generalFinishes: number;
   runTimes: number[];
   leaderNet: Network | null;
   // Solo-mode fields.
@@ -76,7 +75,7 @@ const EMPTY_STATS: Stats = {
   genTicks: 0,
   bestTicks: 0,
   idealTicks: 0,
-  generalTicks: 0,
+  generalFinishes: 0,
   runTimes: [],
   leaderNet: null,
   soloLaps: 0,
@@ -85,12 +84,6 @@ const EMPTY_STATS: Stats = {
   soloLastTicks: 0,
   soloLastDone: false,
 };
-
-// The generalist "finishes all N" worst-case time, or 0 if it can't yet clear
-// every battery track.
-function generalistTicks(score: number): number {
-  return score > 0 && score < FINISH_TIME_BUDGET ? score : 0;
-}
 
 // Seconds string for a tick count ("—" when there's nothing yet).
 function secs(ticks: number): string {
@@ -142,7 +135,7 @@ export function Neuroevolution() {
         ...prev,
         mode: "solo",
         idealTicks: idealRunTicks(track),
-        generalTicks: generalistTicks(w.generalScore),
+        generalFinishes: w.generalFinishes,
         leaderNet: championRef.current,
         soloLaps: car ? Math.min(LAPS_TO_FINISH, Math.floor(car.gatesPassed / gateCount)) : 0,
         soloRunTicks: car ? car.ticks : 0,
@@ -167,7 +160,7 @@ export function Neuroevolution() {
       genTicks,
       bestTicks,
       idealTicks: idealRunTicks(w.track),
-      generalTicks: generalistTicks(w.generalScore),
+      generalFinishes: w.generalFinishes,
       runTimes: w.timeHistory.map((t) => t / 60),
       leaderNet: lead ? lead.net : null,
     }));
@@ -208,6 +201,7 @@ export function Neuroevolution() {
           // Track record is track-specific and resets; the generalist carries
           // over (it's track-independent).
           generalScore: prev.generalScore,
+          generalFinishes: prev.generalFinishes,
           generalNet: prev.generalNet,
           stall: 0,
           history: [],
@@ -249,6 +243,7 @@ export function Neuroevolution() {
         bestTicks: saved.bestTicks,
         bestNet: saved.bestNet ?? null,
         generalScore: saved.generalScore ?? 0,
+        generalFinishes: saved.generalFinishes ?? 0,
         generalNet: saved.generalNet ?? null,
         stall: 0,
         history: saved.history,
@@ -447,6 +442,7 @@ export function Neuroevolution() {
       bestTicks: 0,
       bestNet: null,
       generalScore: 0,
+      generalFinishes: 0,
       generalNet: null,
       stall: 0,
       history: [],
@@ -663,23 +659,19 @@ export function Neuroevolution() {
                   {deltaS !== null && <DeltaChip delta={deltaS} />}
                 </div>
               </div>
-              {/* Generalist: best across the held-out battery (all tracks). */}
+              {/* Generalist: finishes across the held-out battery (all tracks). */}
               <div className="flex items-center justify-between border-t border-[var(--line)] px-3 py-2.5">
                 <span
                   className="font-readout text-[9px] uppercase tracking-[0.25em] text-[var(--muted)]"
-                  title="Best worst-case time across 5 held-out tracks the population never trains on — turn on Vary track to grow this"
+                  title={`How many of ${BATTERY_SIZE} held-out tracks the crowned generalist finishes — tracks the population never trains on. Turn on Vary track to grow this`}
                 >
-                  Generalist · worst of 5
+                  Generalist · finishes
                 </span>
                 <span className="font-telemetry text-lg font-semibold tabular-nums text-[var(--cyan)]">
-                  {stats.generalTicks > 0 ? (
-                    <>
-                      {(stats.generalTicks / TICKS_PER_SEC).toFixed(1)}
-                      <span className="ml-0.5 text-[10px] text-[var(--muted)]">s</span>
-                    </>
-                  ) : (
-                    <span className="text-[var(--muted)]">—</span>
-                  )}
+                  {stats.generalFinishes}
+                  <span className="ml-0.5 text-[10px] text-[var(--muted)]">
+                    /{BATTERY_SIZE}
+                  </span>
                 </span>
               </div>
             </Panel>

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -8,7 +8,7 @@ import type { World } from "./world";
 const KEY = "neuroevolution-world";
 // Bump when the saved shape (track/network layout/scoring/physics) changes, to
 // drop stale saves.
-const VERSION = 6;
+const VERSION = 7;
 
 interface Saved {
   version: number;
@@ -20,6 +20,7 @@ interface Saved {
   // Champions; optional so pre-existing saves still load.
   bestNet?: Network | null;
   generalScore?: number;
+  generalFinishes?: number;
   generalNet?: Network | null;
   history: number[];
   timeHistory: number[];
@@ -36,6 +37,7 @@ export function saveWorld(world: World): void {
       bestTicks: world.bestTicks,
       bestNet: world.bestNet,
       generalScore: world.generalScore,
+      generalFinishes: world.generalFinishes,
       generalNet: world.generalNet,
       history: world.history,
       timeHistory: world.timeHistory,

--- a/src/app/playgrounds/neuroevolution/_lib/persistence.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/persistence.ts
@@ -8,7 +8,7 @@ import type { World } from "./world";
 const KEY = "neuroevolution-world";
 // Bump when the saved shape (track/network layout/scoring/physics) changes, to
 // drop stale saves.
-const VERSION = 7;
+const VERSION = 8;
 
 interface Saved {
   version: number;
@@ -21,6 +21,7 @@ interface Saved {
   bestNet?: Network | null;
   generalScore?: number;
   generalFinishes?: number;
+  generalMeanTicks?: number;
   generalNet?: Network | null;
   history: number[];
   timeHistory: number[];
@@ -38,6 +39,7 @@ export function saveWorld(world: World): void {
       bestNet: world.bestNet,
       generalScore: world.generalScore,
       generalFinishes: world.generalFinishes,
+      generalMeanTicks: world.generalMeanTicks,
       generalNet: world.generalNet,
       history: world.history,
       timeHistory: world.timeHistory,

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -1,9 +1,13 @@
 import { mulberry32 } from "./geometry";
+import { BRAIN_SHAPE } from "./car";
+import { createNetwork } from "./nn";
+import { buildTrack } from "./track";
 import {
   DEFAULT_CONFIG,
   activeCount,
   createWorld,
   leader,
+  lexiFitness,
   stepWorld,
 } from "./world";
 
@@ -56,6 +60,17 @@ describe("stepWorld", () => {
     expect(w.bestTicks).toBe(500);
     expect(w.bestNet).toEqual(recordNet); // captured...
     expect(w.bestNet).not.toBe(recordNet); // ...as a clone
+  });
+
+  it("lexiFitness is deterministic and non-negative", () => {
+    const tracks = [
+      buildTrack(viewport, mulberry32(40)),
+      buildTrack(viewport, mulberry32(41)),
+    ];
+    const brain = createNetwork(BRAIN_SHAPE, mulberry32(42));
+    const a = lexiFitness(brain, tracks);
+    expect(a).toBe(lexiFitness(brain, tracks)); // deterministic
+    expect(a).toBeGreaterThanOrEqual(0);
   });
 
   it("crowns a generalist from the held-out battery each generation", () => {

--- a/src/app/playgrounds/neuroevolution/_lib/world.test.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.test.ts
@@ -79,7 +79,8 @@ describe("stepWorld", () => {
     w.cars.forEach((c) => (c.alive = false)); // end the generation this step
     stepWorld(w, config, mulberry32(31));
     expect(w.generalNet).not.toBeNull();
-    expect(w.generalScore).toBeGreaterThan(0);
+    expect(w.generalScore).toBeGreaterThanOrEqual(0);
+    expect(w.generalFinishes).toBeGreaterThanOrEqual(0);
   });
 
   describe("immigrant diversity rescue", () => {

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -74,6 +74,9 @@ export interface World {
   generalNet: Network | null;
   // How many battery tracks the crowned generalist finishes (for display).
   generalFinishes: number;
+  // Mean finish time (ticks) of the crowned generalist over the battery tracks
+  // it finishes, 0 if none — lets speed be watched after finishes saturate.
+  generalMeanTicks: number;
   // Generations since the last record, for the immigrant diversity rescue.
   stall: number;
   // Best fitness of each completed generation.
@@ -104,6 +107,7 @@ export function createWorld(
     generalScore: 0,
     generalNet: null,
     generalFinishes: 0,
+    generalMeanTicks: 0,
     stall: 0,
     history: [],
     timeHistory: [],
@@ -111,8 +115,14 @@ export function createWorld(
 }
 
 // A fixed, seeded set of held-out tracks the population never trains on — a
-// validation set for measuring how well a brain generalises.
-const BATTERY_SEEDS = [9001, 9002, 9003, 9004, 9005];
+// validation set for measuring how well a brain generalises. Kept large enough
+// that finish-count doesn't saturate (a 5-track set hits 5/5 early and gives a
+// noisy speed signal), so crowning keeps picking the brain that's fastest across
+// many tracks, not just the one lucky on a handful.
+const BATTERY_SEEDS = [
+  9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, 9011, 9012, 9013,
+  9014, 9015, 9016, 9017, 9018, 9019, 9020,
+];
 export const BATTERY_SIZE = BATTERY_SEEDS.length;
 let batteryCache: { key: string; tracks: Track[] } | null = null;
 
@@ -140,11 +150,15 @@ export interface TrackScore {
   lexi: number;
   // How many of the tracks were finished.
   finishes: number;
+  // Mean finish time (ticks) over the finished tracks, 0 if none — the "how
+  // fast" half of the objective, for display.
+  meanTicks: number;
 }
 
 export function scoreTracks(net: Network, tracks: Track[]): TrackScore {
   let lexi = 0;
   let finishes = 0;
+  let tickSum = 0;
   for (const track of tracks) {
     const car = createCar(net, track);
     for (let i = 0; i < FINISH_TIME_BUDGET && car.alive && !car.done; i++) {
@@ -152,12 +166,13 @@ export function scoreTracks(net: Network, tracks: Track[]): TrackScore {
     }
     if (car.done) {
       finishes++;
+      tickSum += car.finishTicks;
       lexi += FINISH_BASE + (FINISH_TIME_BUDGET - car.finishTicks);
     } else {
       lexi += car.gatesPassed;
     }
   }
-  return { lexi, finishes };
+  return { lexi, finishes, meanTicks: finishes ? tickSum / finishes : 0 };
 }
 
 // The "never crash, then go fast" objective, as one number, for vary-track
@@ -290,6 +305,7 @@ function endGeneration(
     const s = scoreTracks(nets[bestIdx], battery);
     world.generalScore = s.lexi;
     world.generalFinishes = s.finishes;
+    world.generalMeanTicks = s.meanTicks;
     world.generalNet = cloneNetwork(nets[bestIdx]);
   }
 

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -32,6 +32,10 @@ export interface SimConfig extends EvolveConfig {
   // exploration (0 rounds disables it).
   stallRounds: number;
   immigrants: number;
+  // Under vary-track, how many fresh random tracks each brain is scored on per
+  // generation (worst-case-ish lexicographic selection). Higher = more general,
+  // more compute.
+  evalTracks: number;
 }
 
 export const DEFAULT_CONFIG: SimConfig = {
@@ -44,6 +48,7 @@ export const DEFAULT_CONFIG: SimConfig = {
   varyTrack: false,
   stallRounds: 12,
   immigrants: 6,
+  evalTracks: 4,
 };
 
 export interface Viewport {
@@ -137,6 +142,30 @@ export function evaluateGenerality(net: Network, battery: Track[]): number {
   return worst;
 }
 
+// Per-finish base, large enough that one more finish always outranks any
+// speed/progress gain elsewhere (speed bonus <= FINISH_TIME_BUDGET, progress
+// small), so the sum below behaves lexicographically: finish first, then speed.
+const FINISH_BASE = 1_000_000;
+
+// Lexicographic fitness over a set of tracks (higher = better): each finished
+// track is worth a big base plus a speed bonus (faster = higher); each DNF is
+// worth only the distance it reached. More finishes always wins; among equal
+// finishes, faster wins; a DNF still climbs by getting further. This is the
+// "never crash, then go fast" objective for vary-track selection.
+export function lexiFitness(net: Network, tracks: Track[]): number {
+  let total = 0;
+  for (const track of tracks) {
+    const car = createCar(net, track);
+    for (let i = 0; i < FINISH_TIME_BUDGET && car.alive && !car.done; i++) {
+      stepCar(car, track);
+    }
+    total += car.done
+      ? FINISH_BASE + (FINISH_TIME_BUDGET - car.finishTicks)
+      : car.gatesPassed;
+  }
+  return total;
+}
+
 // A car still driving: alive and not yet finished.
 function isActive(c: Car): boolean {
   return c.alive && !c.done;
@@ -198,10 +227,24 @@ function endGeneration(
   config: SimConfig,
   rand: () => number,
 ): void {
-  const scored: Scored[] = world.cars.map((c) => ({
-    net: c.net,
-    fitness: c.fitness,
-  }));
+  const dims = { width: world.track.width, height: world.track.height };
+
+  // Selection fitness. Under vary-track, score each brain on K fresh random
+  // tracks with the lexicographic (finish-then-speed) sum, so the population is
+  // bred to finish anything, not just this generation's lucky track. Otherwise
+  // use the live-race fitness. (The held-out battery is never used here.)
+  let scored: Scored[];
+  if (config.varyTrack) {
+    const evalTracks = Array.from({ length: config.evalTracks }, () =>
+      buildTrack(dims, rand),
+    );
+    scored = world.cars.map((c) => ({
+      net: c.net,
+      fitness: lexiFitness(c.net, evalTracks),
+    }));
+  } else {
+    scored = world.cars.map((c) => ({ net: c.net, fitness: c.fitness }));
+  }
   const stats = computeStats(scored);
   world.history.push(stats.best);
   if (stats.best > world.bestEver) world.bestEver = stats.best;
@@ -243,10 +286,7 @@ function endGeneration(
   // Domain randomization reshuffles the course each generation; the fastest-run
   // record only means something on a fixed track, so reset it when varying.
   if (config.varyTrack) {
-    world.track = buildTrack(
-      { width: world.track.width, height: world.track.height },
-      rand,
-    );
+    world.track = buildTrack(dims, rand);
     world.bestTicks = 0;
     world.bestNet = null;
     world.stall = 0;

--- a/src/app/playgrounds/neuroevolution/_lib/world.ts
+++ b/src/app/playgrounds/neuroevolution/_lib/world.ts
@@ -4,7 +4,6 @@
 import {
   BRAIN_SHAPE,
   FINISH_TIME_BUDGET,
-  LAPS_TO_FINISH,
   createCar,
   stepCar,
   type Car,
@@ -68,10 +67,13 @@ export interface World {
   // The brain that set bestTicks — the track record-holder.
   bestNet: Network | null;
   // --- Generalist champion: best across ALL tracks (a robust all-rounder) ---
-  // Worst-case cost over a fixed held-out battery for the best generaliser seen
-  // (0 = none yet; lower is better). Track-independent, so it persists.
+  // Best generaliser seen, selected on a fixed held-out battery by the
+  // lexicographic score (higher = better; worst-case is too flat to rank
+  // generalists). Track-independent, so it persists.
   generalScore: number;
   generalNet: Network | null;
+  // How many battery tracks the crowned generalist finishes (for display).
+  generalFinishes: number;
   // Generations since the last record, for the immigrant diversity rescue.
   stall: number;
   // Best fitness of each completed generation.
@@ -101,6 +103,7 @@ export function createWorld(
     bestNet: null,
     generalScore: 0,
     generalNet: null,
+    generalFinishes: 0,
     stall: 0,
     history: [],
     timeHistory: [],
@@ -110,6 +113,7 @@ export function createWorld(
 // A fixed, seeded set of held-out tracks the population never trains on — a
 // validation set for measuring how well a brain generalises.
 const BATTERY_SEEDS = [9001, 9002, 9003, 9004, 9005];
+export const BATTERY_SIZE = BATTERY_SEEDS.length;
 let batteryCache: { key: string; tracks: Track[] } | null = null;
 
 function validationBattery(width: number, height: number): Track[] {
@@ -123,47 +127,43 @@ function validationBattery(width: number, height: number): Track[] {
   return batteryCache.tracks;
 }
 
-// Worst-case cost of a brain over the battery (lower = more general): its
-// slowest finish, or a heavy penalty plus distance shortfall for any track it
-// fails to finish. Worst-case selection favours "never crashes on the unknown".
-export function evaluateGenerality(net: Network, battery: Track[]): number {
-  let worst = 0;
-  for (const track of battery) {
-    const car = createCar(net, track);
-    for (let i = 0; i < FINISH_TIME_BUDGET && car.alive && !car.done; i++) {
-      stepCar(car, track);
-    }
-    const target = LAPS_TO_FINISH * track.gates.length;
-    const cost = car.done
-      ? car.finishTicks
-      : FINISH_TIME_BUDGET + (target - car.gatesPassed);
-    if (cost > worst) worst = cost;
-  }
-  return worst;
-}
-
 // Per-finish base, large enough that one more finish always outranks any
 // speed/progress gain elsewhere (speed bonus <= FINISH_TIME_BUDGET, progress
 // small), so the sum below behaves lexicographically: finish first, then speed.
 const FINISH_BASE = 1_000_000;
 
-// Lexicographic fitness over a set of tracks (higher = better): each finished
-// track is worth a big base plus a speed bonus (faster = higher); each DNF is
-// worth only the distance it reached. More finishes always wins; among equal
-// finishes, faster wins; a DNF still climbs by getting further. This is the
-// "never crash, then go fast" objective for vary-track selection.
-export function lexiFitness(net: Network, tracks: Track[]): number {
-  let total = 0;
+export interface TrackScore {
+  // Lexicographic fitness (higher = better): each finished track is worth a big
+  // base plus a speed bonus (faster = higher); each DNF is worth only the
+  // distance reached. More finishes always wins; among equal finishes, faster
+  // wins; a DNF still climbs by getting further.
+  lexi: number;
+  // How many of the tracks were finished.
+  finishes: number;
+}
+
+export function scoreTracks(net: Network, tracks: Track[]): TrackScore {
+  let lexi = 0;
+  let finishes = 0;
   for (const track of tracks) {
     const car = createCar(net, track);
     for (let i = 0; i < FINISH_TIME_BUDGET && car.alive && !car.done; i++) {
       stepCar(car, track);
     }
-    total += car.done
-      ? FINISH_BASE + (FINISH_TIME_BUDGET - car.finishTicks)
-      : car.gatesPassed;
+    if (car.done) {
+      finishes++;
+      lexi += FINISH_BASE + (FINISH_TIME_BUDGET - car.finishTicks);
+    } else {
+      lexi += car.gatesPassed;
+    }
   }
-  return total;
+  return { lexi, finishes };
+}
+
+// The "never crash, then go fast" objective, as one number, for vary-track
+// selection.
+export function lexiFitness(net: Network, tracks: Track[]): number {
+  return scoreTracks(net, tracks).lexi;
 }
 
 // A car still driving: alive and not yet finished.
@@ -271,16 +271,26 @@ function endGeneration(
 
   const nets = evolve(scored, config, rand);
 
-  // Generalist champion (separate from the track record): score this
-  // generation's best on the held-out battery and keep whichever brain
-  // generalises best. Track-independent, so it survives track changes.
-  const score = evaluateGenerality(
-    nets[0],
-    validationBattery(world.track.width, world.track.height),
-  );
-  if (world.generalScore === 0 || score < world.generalScore) {
-    world.generalScore = score;
-    world.generalNet = cloneNetwork(nets[0]);
+  // Generalist champion (separate from the track record): pick the best of this
+  // generation's elites on the held-out battery by the lexicographic score
+  // (worst-case is too flat to tell a 4/5 generalist from a 0/5 one), and keep
+  // the best ever. Selecting the champion on held-out data doesn't leak into
+  // breeding, which uses fresh tracks.
+  const battery = validationBattery(dims.width, dims.height);
+  let bestIdx = -1;
+  let bestScore = -Infinity;
+  for (let i = 0; i < config.eliteCount && i < nets.length; i++) {
+    const s = scoreTracks(nets[i], battery);
+    if (s.lexi > bestScore) {
+      bestScore = s.lexi;
+      bestIdx = i;
+    }
+  }
+  if (bestIdx >= 0 && (world.generalNet === null || bestScore > world.generalScore)) {
+    const s = scoreTracks(nets[bestIdx], battery);
+    world.generalScore = s.lexi;
+    world.generalFinishes = s.finishes;
+    world.generalNet = cloneNetwork(nets[bestIdx]);
   }
 
   // Domain randomization reshuffles the course each generation; the fastest-run


### PR DESCRIPTION
### What

Reworks how vary-track mode breeds and crowns the generalist champion so it reliably produces a brain that finishes unseen tracks, fast.

- **Selection**: under vary-track, score each brain on K fresh random tracks per generation with a lexicographic fitness (finish-count first, then speed, with DNF distance as an early gradient), so the population is bred to finish anything rather than the one lucky track it happened to get.
- **Crowning**: pick the generalist champion as the best of the current elites on a held-out battery by that same lexicographic score. The old worst-case-time metric was flat (a 4/5 brain and a 0/5 brain both scored "a DNF"), so it couldn't rank generalists and crowned brains that lagged the population.
- **Battery**: widened the held-out validation set from 5 to 20 tracks so finish-count doesn't saturate instantly and speed is selected over a broad sample, not a noisy handful.
- **Readout**: the Generalist panel now shows finishes-out-of-battery plus the champion's average finish time, so progress is visible after finishes max out.

### Why

Vary-track was producing generalists that still DNF'd on unseen tracks: a single track per generation meant a crash just moved training on, and the crowning metric couldn't tell a strong generalist from a weak one. A probe of a brain trained under the new scheme finishes 50/50 fresh unseen tracks within ~2% of the theoretical optimum lap time.

### Risk / testing

- Persistence version bumped (scoring shape and battery size changed); existing local runs reset on load, which is expected.
- Crowning adds elites x 20 battery sims per generation, roughly +25% on top of breeding, so MAX mode runs slightly fewer generations per second.